### PR TITLE
Guard against conflicting name spaces with other platforms

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,8 +5,8 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: centos-5.10
-  - name: centos-6.5
+  - name: centos-5.11
+  - name: centos-6.6
   - name: centos-7.0
 
 suites:

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -74,6 +74,7 @@ end
       timeout node['yum'][repo]['timeout']
       username node['yum'][repo]['username']
 
+      only_if { platform_family?('rhel') }
       action :create
     end
   end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -42,6 +42,5 @@ describe 'yum-centos::default' do
         end
       end
     end
-
   end
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'yum-centos::default' do
   context 'yum-centos::default uses default attributes' do
     let(:chef_run) do
-      ChefSpec::Runner.new do |node|
+      ChefSpec::Runner.new(platform: 'centos', version: '7.0') do |node|
         node.set['yum']['base']['managed'] = true
         node.set['yum']['updates']['managed'] = true
         node.set['yum']['extras']['managed'] = true


### PR DESCRIPTION
This should resolve chef-cookbooks/yum-fedora#3 which was encountered if you created a cookbook that includes both yum-fedora and yum-centos in the metadata. The updates repository has a namespace conflict which copies the incorrect information into the repo file potentially.