### PR TITLE
Remove CentOS 7 default repos

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,11 +20,19 @@ file '/etc/yum.repos.d/CentOS-Base.repo' do
   action :delete
 end
 
+file '/etc/yum.repos.d/CentOS-CR.repo' do
+  action :delete
+end
+
 file '/etc/yum.repos.d/CentOS-Debuginfo.repo' do
   action :delete
 end
 
 file '/etc/yum.repos.d/CentOS-Media.repo' do
+  action :delete
+end
+
+file '/etc/yum.repos.d/CentOS-Sources.repo' do
   action :delete
 end
 

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -18,12 +18,20 @@ describe 'yum-centos::default' do
         expect(chef_run).to delete_file('/etc/yum.repos.d/CentOS-Base.repo')
       end
 
+      it 'deletes yum_repository[CentOS-CR.repo]' do
+        expect(chef_run).to delete_file('/etc/yum.repos.d/CentOS-CR.repo')
+      end
+
       it 'deletes file[/etc/yum.repos.d/CentOS-Debuginfo.repo]' do
         expect(chef_run).to delete_file('/etc/yum.repos.d/CentOS-Debuginfo.repo')
       end
 
       it 'deletes file[/etc/yum.repos.d/CentOS-Media.repo]' do
         expect(chef_run).to delete_file('/etc/yum.repos.d/CentOS-Media.repo')
+      end
+
+      it 'deletes yum_repository[CentOS-Sources.repo]' do
+        expect(chef_run).to delete_file('/etc/yum.repos.d/CentOS-Sources.repo')
       end
 
       it 'deletes yum_repository[CentOS-Vault.repo]' do


### PR DESCRIPTION
CentOS 7 appears to include 2 new default repos. Remove those by default.