### PR TITLE
fixing to work on rhel

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,7 +21,7 @@
 node.default['yum-centos']['repos'] << value_for_platform(centos: {
                                          '>= 7.0' => 'cr',
                                          :default => 'contrib'
-                                     })
+                                     }) if node.platform?('centos')
 
 node['yum-centos']['repos'].each do |repo|
   if node['yum'][repo]['managed']


### PR DESCRIPTION
when running on rhel (or any platform other than centos) this line https://github.com/chef-cookbooks/yum-centos/blob/master/recipes/default.rb#L21 will append a `nil` value to the array, causing an error.