### PR TITLE
Fix attribute precedence

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,4 @@
-default['yum-centos']['repos'] = %w(base updates extras centosplus fasttrack)
+default['yum-centos']['repos'] = %w(base updates extras centosplus fasttrack) << (value_for_platform(centos: {
+                                         '>= 7.0' => 'cr',
+                                         :default => 'contrib'
+                                     }))

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,11 +18,6 @@
 
 ::Dir["/etc/yum.repos.d/CentOS-*"].select {|f| file f do action :delete end}
 
-node.default['yum-centos']['repos'] << value_for_platform(centos: {
-                                         '>= 7.0' => 'cr',
-                                         :default => 'contrib'
-                                     })
-
 node['yum-centos']['repos'].each do |repo|
   if node['yum'][repo]['managed']
     yum_repository repo do


### PR DESCRIPTION
This is a fix for the inability to override attributes with nil values.
```
node['yum-centos']['repos'].each do |repo|
  node.rm('yum', repo, 'mirrorlist')
end
```
With the inclusion of 'contrib' in the recipe through node.default in the recipe, the above code would not see contrib at compile time and thus not rm the mirrorlist value for contrib thereby letting it leak through. 