### PR TITLE
Allows for redhat platform to be used

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,1 @@
-default['yum-centos']['repos'] = %w(base updates extras centosplus fasttrack) << (value_for_platform(centos: {
-                                                                                                       '>= 7.0' => 'cr',
-                                                                                                       :default => 'contrib'
-                                                                                                     }))
+default['yum-centos']['repos'] = %w(base updates extras centosplus fasttrack) << (value_for_platform( %w(centos redhat) => { '>= 7.0' => 'cr', :default => 'contrib' }))

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,4 @@
-default['yum-centos']['repos'] = %w(base updates extras centosplus fasttrack) << (value_for_platform( %w(centos redhat) => { '>= 7.0' => 'cr', :default => 'contrib' }))
+default['yum-centos']['repos'] = %w(base updates extras centosplus fasttrack) << (value_for_platform(%w(centos redhat) => {
+                                                                                                       '>= 7.0' => 'cr',
+                                                                                                       :default => 'contrib'
+                                                                                                     }))

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Installs and configures the centos Yum repositories'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.4.7'
+version '0.4.8'
 
 depends 'yum', '~> 3.2'
 


### PR DESCRIPTION
When running chef-client on a host with platform=redhat this cookbook would fail to converge due to a nil error on evaluating:

default['yum-centos']['repos'] = %w(base updates extras centosplus fasttrack) << (value_for_platform(centos: {
                                                                                                       '>= 7.0' => 'cr',
                                                                                                       :default => 'contrib'
                                                                                                     }))

Modifying the logic allows for handling of redhat and centos platforms with the same behavior for each.