### PR TITLE
updated to utilize `make_cache` from yum cookbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # yum-centos Cookbook CHANGELOG
 This file is used to list changes made in each version of the yum-centos cookbook.
 
+## v0.4.12 (2015-12-07)
+- updated to actually utilize the `make_cache` option from the yum cookbook
+
 ## v0.4.11 (2015-12-07)
 - Use releasever yum variable for the path to the GPG key to avoid a case statement in the cookbook attributes file
 

--- a/attributes/base.rb
+++ b/attributes/base.rb
@@ -2,6 +2,7 @@ default['yum']['base']['repositoryid'] = 'base'
 default['yum']['base']['mirrorlist'] = 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os'
 default['yum']['base']['description'] = 'CentOS-$releasever - Base'
 default['yum']['base']['enabled'] = true
+default['yum']['base']['make_cache'] = true
 default['yum']['base']['managed'] = true
 default['yum']['base']['gpgcheck'] = true
 default['yum']['base']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever'

--- a/attributes/contrib.rb
+++ b/attributes/contrib.rb
@@ -2,6 +2,7 @@ default['yum']['contrib']['repositoryid'] = 'contrib'
 default['yum']['contrib']['description'] = 'CentOS-$releasever - Contrib'
 default['yum']['contrib']['mirrorlist'] = 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib'
 default['yum']['contrib']['enabled'] = false
+default['yum']['contrib']['make_cache'] = true
 default['yum']['contrib']['managed'] = false
 default['yum']['contrib']['gpgcheck'] = true
 case node['platform_version'].to_i

--- a/attributes/cr.rb
+++ b/attributes/cr.rb
@@ -2,6 +2,7 @@ default['yum']['cr']['repositoryid'] = 'cr'
 default['yum']['cr']['description'] = 'CentOS-$releasever - Continuous Release'
 default['yum']['cr']['mirrorlist'] = 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=cr'
 default['yum']['cr']['enabled'] = false
+default['yum']['cr']['make_cache'] = true
 default['yum']['cr']['managed'] = false
 default['yum']['cr']['gpgcheck'] = true
 case node['platform_version'].to_i

--- a/attributes/extras.rb
+++ b/attributes/extras.rb
@@ -2,6 +2,7 @@ default['yum']['extras']['repositoryid'] = 'extras'
 default['yum']['extras']['description'] = 'CentOS-$releasever - Extras'
 default['yum']['extras']['mirrorlist'] = 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras'
 default['yum']['extras']['enabled'] = true
+default['yum']['extras']['make_cache'] = true
 default['yum']['extras']['managed'] = true
 default['yum']['extras']['gpgcheck'] = true
 case node['platform_version'].to_i

--- a/attributes/fasttrack.rb
+++ b/attributes/fasttrack.rb
@@ -2,6 +2,7 @@ default['yum']['fasttrack']['repositoryid'] = 'fasttrack'
 default['yum']['fasttrack']['description'] = 'CentOS-$releasever - fasttrack'
 default['yum']['fasttrack']['mirrorlist'] = 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=fasttrack&infra=$infra'
 default['yum']['fasttrack']['enabled'] = false
+default['yum']['fasttrack']['make_cache'] = true
 default['yum']['fasttrack']['managed'] = false
 default['yum']['fasttrack']['gpgcheck'] = true
 case node['platform_version'].to_i

--- a/attributes/plus.rb
+++ b/attributes/plus.rb
@@ -2,6 +2,7 @@ default['yum']['centosplus']['repositoryid'] = 'centosplus'
 default['yum']['centosplus']['description'] = 'CentOS-$releasever - Centosplus'
 default['yum']['centosplus']['mirrorlist'] = 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus'
 default['yum']['centosplus']['enabled'] = false
+default['yum']['centosplus']['make_cache'] = true
 default['yum']['centosplus']['managed'] = false
 default['yum']['centosplus']['gpgcheck'] = true
 case node['platform_version'].to_i

--- a/attributes/updates.rb
+++ b/attributes/updates.rb
@@ -2,6 +2,7 @@ default['yum']['updates']['repositoryid'] = 'updates'
 default['yum']['updates']['description'] = 'CentOS-$releasever - Updates'
 default['yum']['updates']['mirrorlist'] = 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates'
 default['yum']['updates']['enabled'] = true
+default['yum']['updates']['make_cache'] = true
 default['yum']['updates']['managed'] = true
 default['yum']['updates']['gpgcheck'] = true
 case node['platform_version'].to_i

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,9 +4,9 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Installs and configures the centos Yum repositories'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.4.11'
+version '0.4.12'
 
-depends 'yum', '~> 3.2'
+depends 'yum', '~> 3.10.0'
 
 supports 'centos'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -40,6 +40,7 @@ node['yum-centos']['repos'].each do |repo|
     include_config node['yum'][repo]['include_config'] unless node['yum'][repo]['include_config'].nil?
     includepkgs node['yum'][repo]['includepkgs'] unless node['yum'][repo]['includepkgs'].nil?
     keepalive node['yum'][repo]['keepalive'] unless node['yum'][repo]['keepalive'].nil?
+    make_cache node['yum'][repo]['make_cache'] unless node['yum'][repo]['make_cache'].nil?
     max_retries node['yum'][repo]['max_retries'] unless node['yum'][repo]['max_retries'].nil?
     metadata_expire node['yum'][repo]['metadata_expire'] unless node['yum'][repo]['metadata_expire'].nil?
     mirror_expire node['yum'][repo]['mirror_expire'] unless node['yum'][repo]['mirror_expire'].nil?


### PR DESCRIPTION
this cookbook doesn't utilize the `make_cache` option that the parent yum cookbook has.  this fix allows that attribute/value to be passed in now then as an attribute, and so you don't have to just make a custom  yum resource if you wanted to actually not do make_cache.