### PR TITLE
XenServer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The yum-centos cookbook takes over management of the default repositoryids that 
 ### Platforms
 
 - CentOS
+- XenServer
 
 ### Chef
 
@@ -20,7 +21,7 @@ The yum-centos cookbook takes over management of the default repositoryids that 
 
 ## Attributes
 
-The following attributes are set by default
+The following attributes are set by default. These values differ slightly on XenServer.
 
 ```ruby
 default['yum']['base']['repositoryid'] = 'base'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,4 @@
-contrib = value_for_platform(%w(centos redhat) => {
+contrib = value_for_platform(%w(centos redhat xenserver) => {
                                '>= 7.0' => 'cr',
                                :default => 'contrib',
                              })

--- a/attributes/xenserver.rb
+++ b/attributes/xenserver.rb
@@ -1,0 +1,13 @@
+if platform?('xenserver')
+  default['yum-centos']['repos'].each do |repo|
+    default['yum'][repo].each do |key, value|
+      if value.is_a?(String)
+        default['yum'][repo][key] =
+          value.gsub('$releasever', node['platform_version'].to_i.to_s)
+      end
+    end
+
+    default['yum'][repo]['mirrorlist'] = nil
+    default['yum'][repo]['exclude'] = 'kernel kernel-abi-whitelists kernel-debug kernel-debug-devel kernel-devel kernel-doc kernel-tools kernel-tools-libs kernel-tools-libs-devel linux-firmware biosdevname centos-release systemd* stunnel kexec-tools ocaml*'
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,6 +9,7 @@ version '2.1.0'
 depends 'compat_resource', '>= 12.16.3'
 
 supports 'centos'
+supports 'xenserver'
 
 source_url 'https://github.com/chef-cookbooks/yum-centos'
 issues_url 'https://github.com/chef-cookbooks/yum-centos/issues'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,6 +16,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ruby_block 'xenserver $releasever' do
+  only_if { platform?('xenserver') }
+
+  block do
+    cmd = shell_out!('rpm -q --provides xenserver-release | ' \
+                     'sed -n "s/^centos-release = \(.*\)/\1/p"')
+
+    releasever = cmd.stdout.chomp.sub(/\.el.*/, '').tr('^0-9', '.')
+
+    node.default['yum-centos']['repos'].each do |repo|
+      dir = repo == 'base' ? 'os' : repo
+      node.default['yum'][repo]['baseurl'] =
+        "http://mirror.centos.org/centos/#{releasever}/#{dir}/$basearch/"
+    end
+  end
+end
+
 ::Dir['/etc/yum.repos.d/CentOS-*'].each do |f|
   file f do
     action :delete
@@ -26,7 +43,13 @@ node['yum-centos']['repos'].each do |repo|
   next unless node['yum'][repo]['managed']
   yum_repository repo do
     node['yum'][repo].each do |config, value|
-      send(config.to_sym, value) unless value.nil? || config == 'managed'
+      case config
+      when 'managed'
+      when 'baseurl'
+        send(config.to_sym, lazy { value })
+      else
+        send(config.to_sym, value) unless value.nil?
+      end
     end
   end
 end


### PR DESCRIPTION
XenServer cannot use the usual repository URLs for three reasons.

First, the usual $releasever of 7 is no good because attempting to update to 7.3 causes too many package conflicts when XenServer is currently built around 7.2.

Second, even if $releasever was 7.2 or 7.2.1511, for some reason the mirrorlist script only accepts a release value of 7 so baseurl must be used in order to avoid 7.3.

Last, XenServer doesn't set $releasever to 7 or 7.2 or even 7.2.1511. Bizarrely, it sets it to 7-2.1511.el7.centos.2.10, which isn't much use in any context. This value is not picked up by Ohai so we have to run the rpm command to examine the xenserver-release provider list. The baseurl therefore needs to be set by the recipe rather than the attributes. Making the baseurl resource property lazy
prevents us from doing a `nil?` check but that's okay because this property does not have a default value.

Although XenServer leaves all the repositories disabled by default, it does exclude certain packages to prevent you from breaking the system if you do decide to enable them. This exclusion list is mirrored here.

This may seem like a lot of hassle for a relatively obscure platform but anyone wanting to use Chef on XenServer will almost certainly need to reconfigure these repositories in order to install anything.