### PR TITLE
add new cleanup_repos flag

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,3 +11,6 @@ default['yum-centos']['repos'] = %W(
   fasttrack
   #{contrib}
 )
+
+# NOTE: if set to false, repositories starting with CentOS-SCLo-* won't be deleted
+default['yum-centos']['keep_scl_repositories'] = true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,7 +33,13 @@ ruby_block 'xenserver $releasever' do
   end
 end
 
-::Dir['/etc/yum.repos.d/CentOS-*'].each do |f|
+if node['yum-centos']['keep_scl_repositories']
+  repositories_to_delete = ::Dir['/etc/yum.repos.d/CentOS-*'].reject { |repo| repo.include?('CentOS-SCLo-') }
+else
+  repositories_to_delete = ::Dir['/etc/yum.repos.d/CentOS-*']
+end
+
+repositories_to_delete.each do |f|
   file f do
     action :delete
   end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,11 +33,11 @@ ruby_block 'xenserver $releasever' do
   end
 end
 
-if node['yum-centos']['keep_scl_repositories']
-  repositories_to_delete = ::Dir['/etc/yum.repos.d/CentOS-*'].reject { |repo| repo.include?('CentOS-SCLo-') }
-else
-  repositories_to_delete = ::Dir['/etc/yum.repos.d/CentOS-*']
-end
+repositories_to_delete = if node['yum-centos']['keep_scl_repositories']
+                           ::Dir['/etc/yum.repos.d/CentOS-*'].reject { |repo| repo.include?('CentOS-SCLo-') }
+                         else
+                           ::Dir['/etc/yum.repos.d/CentOS-*']
+                         end
 
 repositories_to_delete.each do |f|
   file f do

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -5,6 +5,8 @@ set :backend, :exec
 puts "os: #{os}"
 
 describe 'yum-centos::default' do
+  command('yum install -y centos-release-scl-rh centos-release-scl')
+
   context 'deleting default yum channel repositories' do
     describe file '/etc/yum.repos.d/CentOS-Base.repo' do
       it { should_not exist }
@@ -26,6 +28,14 @@ describe 'yum-centos::default' do
     end
     describe file '/etc/yum.repos.d/CentOS-CR.repo' do
       it { should_not exist }
+    end
+  end
+
+  content 'keeping SCL repositories' do
+    ['CentOS-SCLo-scl.repo', 'CentOS-SCLo-scl-rh.repo'].each do |scl_repo|
+      describe file "/etc/yum.repos.d/#{scl_repo}" do
+        it { should exist }
+      end
     end
   end
 


### PR DESCRIPTION
### Description

Add new `keep_scl_repositories` flag to prevent (or not) deleting repos installed through `centos-release-scl-rh` and `centos-release-scl`.

The workaround is to manage the repositories by hand with `yum_repository` resource and using a different name but the actual scl packages are the official way to go.

Should not break anything as these repos don't exist by default and are only installed through both packages mentioned above.

### Issues Resolved

https://github.com/chef-cookbooks/yum-centos/issues/29

Thanks for looking at it 🍴 