### PR TITLE
Add various SIG repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@
             - 'centos-8'
           suite:
             - 'default'
+            - 'vault'
             - 'all'
         fail-fast: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 This file is used to list changes made in each version of the yum-centos cookbook.
 
+## Unreleased
+
+### Added
+- Add various SIG repos
+- Suite and InSpec tests for vault recipe
+
+### Changed
+- Changed to using $releasever instead of using ``node['platform_version'].to_i``
+- Remove appended ``&infra=$infra`` to mirrorlist URLs as they are not required and make testing easier
+- Update InSpec tests to use yum.repo where it makes sense
+- Re-enable debuginfo and cr repos for CentOS 8 now that they are available
+
+### Deprecated
+- Breaking Change: Remove ``node['yum-centos']['keep_scl_repositories']`` attribute since we manage SCL repos directly
+  now
+
+### Fixed
+- Fix vault recipe and add ``node['yum-centos']['vault_release']`` attribute for setting which version to use. By
+  default use previous release.
+
 ## 3.2.0 (2019-10-14)
 
 - Add support for CentOS 8 - [@ramereth](https://github.com/ramereth)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,54 @@
 
 [![Cookbook Version](https://img.shields.io/cookbook/v/yum-centos.svg)](https://supermarket.chef.io/cookbooks/yum-centos)
 
-The yum-centos cookbook takes over management of the default repositoryids that ship with CentOS systems. It allows attribute manipulation of `base`, `updates`, `extras`, `centosplus`, `contrib`, and `fasttrack`.
+The yum-centos cookbook takes over management of the default and optional repositoryids that ship with CentOS systems.
+
+Below is a table showing which repositoryids we manage that are shipped by default with CentOS via the centos-release
+package:
+
+| Repo ID          | CentOS 6         | CentOS 7         | CentOS 8         |
+| ---------------- | :--------------: | :--------------: | :--------------: |
+| appstream        |       :x:        |       :x:        |:heavy_check_mark:|
+| base             |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+| centos-kernel    |       :x:        |:heavy_check_mark:|       :x:        |
+| centosplus       |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+| contrib          |:heavy_check_mark:|       :x:        |       :x:        |
+| cr               |       :x:        |:heavy_check_mark:|:heavy_check_mark:|
+| debuginfo        |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+| extras           |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+| fasttrack        |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
+| highavailability |       :x:        |       :x:        |:heavy_check_mark:|
+| powertools       |       :x:        |       :x:        |:heavy_check_mark:|
+| updates          |:heavy_check_mark:|:heavy_check_mark:|       :x:        |
+
+Additionally, this cookbook can manage the following CentOS repositories that can *optionally* be installed.  The table
+below displays each repositories we support, which platform version they are supported on and what upstream release
+package it effectively replaces. Some of these repositories may depend on another related repository. This cookbook
+*does not* automatically account for such dependencies and this is up to the user to configure the appropriate
+repositories.
+
+While upstream may provide additional versions for the repositories below, we only maintain the current release. Users
+are welcome to override those attributes as they see fit for their environment.
+
+| Repo ID                 | CentOS 6         | CentOS 7         | CentOS 8         | Upstream release package     |
+| ----------------------- | :--------------: | :--------------: | :--------------: | ---------------------------- |
+| centos-ansible          |       :x:        |:heavy_check_mark:|:heavy_check_mark:| centos-release-ansible-29    |
+| centos-azure            |:heavy_check_mark:|:heavy_check_mark:|       :x:        | centos-release-azure         |
+| centos-ceph             |       :x:        |:heavy_check_mark:|:heavy_check_mark:| centos-release-ceph-octopus (C8) <br> centos-release-ceph-nautilus (C7) |
+| centos-dotnet           |       :x:        |:heavy_check_mark:|       :x:        | centos-release-dotnet        |
+| centos-fdio             |       :x:        |:heavy_check_mark:|       :x:        | centos-release-fdio          |
+| centos-gluster          |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:| centos-release-gluster7      |
+| centos-nfs-ganesha      |       :x:        |:heavy_check_mark:|:heavy_check_mark:| centos-release-nfs-ganesha30 |
+| centos-openshift-origin |       :x:        |:heavy_check_mark:|       :x:        | centos-release-openshift-origin311 |
+| centos-openstack        |       :x:        |:heavy_check_mark:|:heavy_check_mark:| centos-release-openstack-ussuri (C8) <br> centos-release-openstack-train (C7) |
+| centos-opstools         |       :x:        |:heavy_check_mark:|:heavy_check_mark:| centos-release-opstools      |
+| centos-ovirt            |       :x:        |:heavy_check_mark:|       :x:        | centos-release-ovirt43       |
+| centos-qemu-ev          |       :x:        |:heavy_check_mark:|       :x:        | centos-release-qemu-ev       |
+| centos-qpid-proton      |       :x:        |       :x:        |:heavy_check_mark:| centos-release-qpid-proton   |
+| centos-rabbitmq         |       :x:        |       :x:        |:heavy_check_mark:| centos-release-rabbitmq-38   |
+| centos-sclo-rh          |:heavy_check_mark:|:heavy_check_mark:|       :x:        | centos-release-scl-rh        |
+| centos-sclo             |:heavy_check_mark:|:heavy_check_mark:|       :x:        | centos-release-scl           |
+| centos-virt-xen         |:heavy_check_mark:|:heavy_check_mark:|       :x:        | centos-release-xen-412       |
 
 ## Requirements
 
@@ -21,81 +68,91 @@ The yum-centos cookbook takes over management of the default repositoryids that 
 
 ## Attributes
 
-The following attributes are set by default. These values differ slightly on XenServer.
+See individual repository attribute files for defaults.
+
+If using the vault recipe, you can set ``node['yum-centos']['vault_release']`` or use the defaults which are shown below:
 
 ```ruby
-default['yum']['base']['repositoryid'] = 'base'
-default['yum']['base']['mirrorlist'] = "http://mirrorlist.centos.org/?release=#{node['platform_version'].to_i}&arch=$basearch&repo=os"
-default['yum']['base']['description'] = "CentOS-#{node['platform_version'].to_i} - Base"
-default['yum']['base']['enabled'] = true
-default['yum']['base']['managed'] = true
-default['yum']['base']['gpgcheck'] = true
-default['yum']['base']['gpgkey'] = "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-#{node['platform_version'].to_i}"
+# Vault only provides binary packages for the previous release
+default['yum-centos']['vault_release'] =
+  value_for_platform(%w(centos redhat xenserver) =>
+  {
+      '>= 8.0' => '8.0.1905',
+      '~> 7.0' => '7.7.1908',
+      '< 7.0' => '6.9',
+  })
 ```
 
-```ruby
-default['yum']['contrib']['repositoryid'] = 'contrib'
-default['yum']['contrib']['description'] = "CentOS-#{node['platform_version'].to_i} - Contrib"
-default['yum']['contrib']['mirrorlist'] = "http://mirrorlist.centos.org/?release=#{node['platform_version'].to_i}&arch=$basearch&repo=contrib"
-default['yum']['contrib']['enabled'] = false
-default['yum']['contrib']['managed'] = false
-default['yum']['contrib']['gpgcheck'] = true
-default['yum']['contrib']['gpgkey'] = "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-#{node['platform_version'].to_i}"
-```
+Some repositories provide a version attribute to set which version of the repository to use. Changing these will also
+update the version used in ``mirrorlist`` and ``description``.
 
 ```ruby
-default['yum']['extras']['repositoryid'] = 'extras'
-default['yum']['extras']['description'] = 'CentOS-#{node['platform_version'].to_i} - Extras'
-default['yum']['extras']['mirrorlist'] = "http://mirrorlist.centos.org/?release=#{node['platform_version'].to_i}&arch=$basearch&repo=extras"
-default['yum']['extras']['enabled'] = true
-default['yum']['extras']['managed'] = true
-default['yum']['extras']['gpgcheck'] = true
-default['yum']['extras']['gpgkey'] = "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-#{node['platform_version'].to_i}"
+default['yum-centos']['ansible_version'] = '29'
+default['yum-centos']['ceph_version'] =
+  value_for_platform(%w(centos redhat xenserver) =>
+  {
+      '>= 8.0' => 'octopus',
+      '~> 7.0' => 'nautilus',
+      '< 7.0' => '',
+  })
+default['yum-centos']['gluster_version'] = '7'
+default['yum-centos']['nfs_ganesha_version'] =
+  value_for_platform(%w(centos redhat xenserver) =>
+  {
+      '>= 8.0' => '3',
+      '~> 7.0' => '30',
+  })
+default['yum-centos']['openshift_version'] = '311'
+default['yum-centos']['openstack_version'] =
+  value_for_platform(%w(centos redhat xenserver) =>
+  {
+      '>= 8.0' => 'ussuri',
+      '~> 7.0' => 'train',
+      '< 7.0' => '',
+  })
+default['yum-centos']['opstools_version'] =
+  value_for_platform(%w(centos redhat xenserver) =>
+  {
+      '>= 8.0' => '-collectd-5',
+      '< 8.0' => '',
+  })
+default['yum-centos']['ovirt_version'] = '4.3'
+default['yum-centos']['rabbitmq_version'] = '38'
+default['yum-centos']['virt_xen_version'] =
+  value_for_platform(%w(centos redhat xenserver) =>
+  {
+      '~> 7.0' => '412',
+      '< 7.0' => '410',
+  })
 ```
 
-```ruby
-default['yum']['centosplus']['repositoryid'] = 'centosplus'
-default['yum']['centosplus']['description'] = 'CentOS-#{node['platform_version'].to_i} - Centosplus'
-default['yum']['centosplus']['mirrorlist'] = 'http://mirrorlist.centos.org/?release=#{node['platform_version'].to_i}&arch=$basearch&repo=centosplus'
-default['yum']['centosplus']['enabled'] = false
-default['yum']['centosplus']['managed'] = false
-default['yum']['centosplus']['gpgcheck'] = true
-default['yum']['centosplus']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-#{node['platform_version'].to_i}'
-```
+_NOTE: If you are migrating from using `node['yum-centos']['keep_scl_repositories']`, you will need to do the following
+  to enable the repositories using this cookbook:_
 
 ```ruby
-default['yum']['updates']['repositoryid'] = 'updates'
-default['yum']['updates']['description'] = 'CentOS-#{node['platform_version'].to_i} - Updates'
-default['yum']['updates']['mirrorlist'] = 'http://mirrorlist.centos.org/?release=#{node['platform_version'].to_i}&arch=$basearch&repo=updates'
-default['yum']['updates']['enabled'] = true
-default['yum']['updates']['managed'] = true
-default['yum']['updates']['gpgcheck'] = true
-default['yum']['updates']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-#{node['platform_version'].to_i}'
-```
+node.default['yum']['centos-sclo']['enabled'] = true
+node.default['yum']['centos-sclo']['managed'] = true
+node.default['yum']['centos-sclo-rh']['enabled'] = true
+node.default['yum']['centos-sclo-rh']['managed'] = true
 
-```ruby
-default['yum']['fasttrack']['repositoryid'] = 'fasttrack'
-default['yum']['fasttrack']['description'] = 'CentOS-#{node['platform_version'].to_i} - fasttrack'
-default['yum']['fasttrack']['mirrorlist'] = 'http://mirrorlist.centos.org/?release=#{node['platform_version'].to_i}&arch=$basearch&repo=fasttrack&infra=$infra'
-default['yum']['fasttrack']['enabled'] = false
-default['yum']['fasttrack']['managed'] = false
-default['yum']['fasttrack']['gpgcheck'] = true
-default['yum']['fasttrack']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-#{node['platform_version'].to_i}'
+include_recipe 'yum-centos'
 ```
 
 ## Recipes
 
-- `yum-centos::default` Generates `yum_repository` configs for latest CentOS release. By default the `base`, `extras`, `updates` repos are enabled.
+- `yum-centos::default` Generates `yum_repository` configs for latest CentOS release. By default the `base`, `extras`,
+  and `updates` repos are enabled on CentOS 7. For CentOS 8, `base`, `extras` and `appstream` repos are enabled by
+  default.
 
 _NOTE: If you are running an older CentOS release, i.e. 6.7 when 6.8 is the latest 6.x release, you may want to consider the `yum-centos::vault` recipe._
 
 ```ruby
   yum_repository 'base' do
-    mirrorlist 'http://mirrorlist.centos.org/?release=#{node['platform_version'].to_i}&arch=$basearch&repo=os'
-    description 'CentOS-#{node['platform_version'].to_i} - Base'
+    mirrorlist 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os'
+    description 'CentOS-$releasever - Base'
     enabled true
     gpgcheck true
-    gpgkey 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-#{node['platform_version'].to_i}'
+    gpgkey 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever'
   end
 ```
 

--- a/attributes/appstream.rb
+++ b/attributes/appstream.rb
@@ -1,7 +1,8 @@
 default['yum']['appstream']['repositoryid'] = 'appstream'
-default['yum']['appstream']['description'] = "CentOS-#{node['platform_version'].to_i} - AppStream"
+default['yum']['appstream']['description'] = 'CentOS-$releasever - AppStream'
 default['yum']['appstream']['enabled'] = true
 default['yum']['appstream']['make_cache'] = true
 default['yum']['appstream']['managed'] = true
-default['yum']['appstream']['mirrorlist'] = "http://mirrorlist.centos.org/?release=#{node['platform_version'].to_i}&arch=$basearch&repo=AppStream&infra=$infra"
+default['yum']['appstream']['mirrorlist'] =
+  'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=AppStream'
 default['yum']['appstream']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial'

--- a/attributes/base.rb
+++ b/attributes/base.rb
@@ -1,12 +1,12 @@
 default['yum']['base']['repositoryid'] = 'base'
-default['yum']['base']['description'] = "CentOS-#{node['platform_version'].to_i} - Base"
+default['yum']['base']['description'] = 'CentOS-$releasever - Base'
 default['yum']['base']['enabled'] = true
 default['yum']['base']['make_cache'] = true
 default['yum']['base']['managed'] = true
 if node['platform_version'].to_i >= 8
-  default['yum']['base']['mirrorlist'] = "http://mirrorlist.centos.org/?release=#{node['platform_version'].to_i}&arch=$basearch&repo=BaseOS&infra=$infra"
+  default['yum']['base']['mirrorlist'] = 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=BaseOS'
   default['yum']['base']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial'
 else
-  default['yum']['base']['mirrorlist'] = "http://mirrorlist.centos.org/?release=#{node['platform_version'].to_i}&arch=$basearch&repo=os"
-  default['yum']['base']['gpgkey'] = "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-#{node['platform_version'].to_i}"
+  default['yum']['base']['mirrorlist'] = 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os'
+  default['yum']['base']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever'
 end

--- a/attributes/centos-ansible.rb
+++ b/attributes/centos-ansible.rb
@@ -1,0 +1,30 @@
+# centos-release-ansible-29 : CentOS 7
+# centos-release-ansible-29 : CentOS 8
+ver = node['yum-centos']['ansible_version']
+
+default['yum']['centos-ansible']['repositoryid'] = 'centos-ansible'
+default['yum']['centos-ansible']['description'] = "CentOS Configmanagement SIG - #{ver}"
+default['yum']['centos-ansible']['enabled'] = false
+default['yum']['centos-ansible']['make_cache'] = true
+default['yum']['centos-ansible']['managed'] = false
+default['yum']['centos-ansible']['mirrorlist'] =
+  "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=configmanagement-ansible-#{ver}"
+default['yum']['centos-ansible']['gpgkey'] = 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-ConfigManagement'
+# testing
+default['yum']['centos-ansible-testing']['repositoryid'] = 'centos-ansible-testing'
+default['yum']['centos-ansible-testing']['description'] = "CentOS Configmanagement SIG - ansible#{ver} - Testing"
+default['yum']['centos-ansible-testing']['enabled'] = false
+default['yum']['centos-ansible-testing']['make_cache'] = true
+default['yum']['centos-ansible-testing']['managed'] = false
+default['yum']['centos-ansible-testing']['gpgcheck'] = false
+default['yum']['centos-ansible-testing']['baseurl'] =
+  "http://buildlogs.centos.org/centos/$releasever/configmanagement/$basearch/ansible-#{ver}/"
+# debuginfo
+default['yum']['centos-ansible-debuginfo']['repositoryid'] = 'centos-ansible-debuginfo'
+default['yum']['centos-ansible-debuginfo']['description'] = "CentOS Configmanagement SIG - ansible#{ver} - Debuginfo"
+default['yum']['centos-ansible-debuginfo']['enabled'] = false
+default['yum']['centos-ansible-debuginfo']['make_cache'] = true
+default['yum']['centos-ansible-debuginfo']['managed'] = false
+default['yum']['centos-ansible-debuginfo']['gpgcheck'] = false
+default['yum']['centos-ansible-debuginfo']['baseurl'] =
+  'http://debuginfo.centos.org/$contentdir/$releasever/configmanagement/$basearch/'

--- a/attributes/centos-azure.rb
+++ b/attributes/centos-azure.rb
@@ -1,0 +1,19 @@
+# centos-release-azure : CentOS 6
+# centos-release-azure : CentOS 7
+default['yum']['centos-azure']['repositoryid'] = 'centos-azure'
+default['yum']['centos-azure']['description'] = 'CentOS-$releasever - Azure'
+default['yum']['centos-azure']['enabled'] = false
+default['yum']['centos-azure']['make_cache'] = true
+default['yum']['centos-azure']['managed'] = false
+default['yum']['centos-azure']['mirrorlist'] =
+  'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=virt-azure'
+default['yum']['centos-azure']['gpgkey'] = 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Virtualization'
+# testing
+default['yum']['centos-azure-testing']['repositoryid'] = 'centos-azure-testing'
+default['yum']['centos-azure-testing']['description'] = 'CentOS-$releasever - Azure - Testing'
+default['yum']['centos-azure-testing']['enabled'] = false
+default['yum']['centos-azure-testing']['make_cache'] = true
+default['yum']['centos-azure-testing']['managed'] = false
+default['yum']['centos-azure-testing']['gpgcheck'] = false
+default['yum']['centos-azure-testing']['baseurl'] =
+  'https://buildlogs.centos.org/centos/$releasever/virt/$basearch/azure/'

--- a/attributes/centos-ceph.rb
+++ b/attributes/centos-ceph.rb
@@ -1,0 +1,21 @@
+# centos-release-ceph-nautilus : CentOS 7
+# centos-release-ceph-octopus  : CentOS 8
+ver = node['yum-centos']['ceph_version']
+
+default['yum']['centos-ceph']['repositoryid'] = 'centos-ceph'
+default['yum']['centos-ceph']['description'] = "CentOS-$releasever - Ceph #{ver.capitalize}"
+default['yum']['centos-ceph']['enabled'] = false
+default['yum']['centos-ceph']['make_cache'] = true
+default['yum']['centos-ceph']['managed'] = false
+default['yum']['centos-ceph']['mirrorlist'] =
+  "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=storage-ceph-#{ver}"
+default['yum']['centos-ceph']['gpgkey'] = 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Storage'
+# testing
+default['yum']['centos-ceph-testing']['repositoryid'] = 'centos-ceph-testing'
+default['yum']['centos-ceph-testing']['description'] = "CentOS-$releasever - Ceph #{ver.capitalize} - Testing"
+default['yum']['centos-ceph-testing']['enabled'] = false
+default['yum']['centos-ceph-testing']['make_cache'] = true
+default['yum']['centos-ceph-testing']['managed'] = false
+default['yum']['centos-ceph-testing']['gpgcheck'] = false
+default['yum']['centos-ceph-testing']['baseurl'] =
+  "https://buildlogs.centos.org/centos/$releasever/storage/$basearch/ceph-#{ver}/"

--- a/attributes/centos-dotnet.rb
+++ b/attributes/centos-dotnet.rb
@@ -1,0 +1,9 @@
+# centos-release-dotnet : CentOS 7 only
+default['yum']['centos-dotnet']['repositoryid'] = 'centos-dotnet'
+default['yum']['centos-dotnet']['description'] = 'CentOS-$releasever - Dotnet'
+default['yum']['centos-dotnet']['enabled'] = false
+default['yum']['centos-dotnet']['make_cache'] = true
+default['yum']['centos-dotnet']['managed'] = false
+default['yum']['centos-dotnet']['mirrorlist'] =
+  'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=dotnet'
+default['yum']['centos-dotnet']['gpgkey'] = 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Storage'

--- a/attributes/centos-fdio.rb
+++ b/attributes/centos-fdio.rb
@@ -1,0 +1,18 @@
+# centos-release-fdio : CentOS 7 only
+default['yum']['centos-fdio']['repositoryid'] = 'centos-fdio'
+default['yum']['centos-fdio']['description'] = 'CentOS-$releasever - fd.io'
+default['yum']['centos-fdio']['enabled'] = false
+default['yum']['centos-fdio']['make_cache'] = true
+default['yum']['centos-fdio']['managed'] = false
+default['yum']['centos-fdio']['mirrorlist'] =
+  'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=nfv-fdio'
+default['yum']['centos-fdio']['gpgkey'] = 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-NFV'
+# testing
+default['yum']['centos-fdio-testing']['repositoryid'] = 'centos-fdio-testing'
+default['yum']['centos-fdio-testing']['description'] = 'CentOS-$releasever - fd.io - Testing'
+default['yum']['centos-fdio-testing']['enabled'] = false
+default['yum']['centos-fdio-testing']['make_cache'] = true
+default['yum']['centos-fdio-testing']['managed'] = false
+default['yum']['centos-fdio-testing']['gpgcheck'] = false
+default['yum']['centos-fdio-testing']['baseurl'] =
+  'https://buildlogs.centos.org/centos/$releasever/nfv/$basearch/fdio/'

--- a/attributes/centos-gluster.rb
+++ b/attributes/centos-gluster.rb
@@ -1,0 +1,20 @@
+# centos-release-gluster7
+ver = node['yum-centos']['gluster_version']
+
+default['yum']['centos-gluster']['repositoryid'] = 'centos-gluster'
+default['yum']['centos-gluster']['description'] = "CentOS-$releasever - Gluster #{ver}"
+default['yum']['centos-gluster']['enabled'] = false
+default['yum']['centos-gluster']['make_cache'] = true
+default['yum']['centos-gluster']['managed'] = false
+default['yum']['centos-gluster']['mirrorlist'] =
+  "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=storage-gluster-#{ver}"
+default['yum']['centos-gluster']['gpgkey'] = 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Storage'
+# testing
+default['yum']['centos-gluster-testing']['repositoryid'] = 'centos-gluster-testing'
+default['yum']['centos-gluster-testing']['description'] = "CentOS-$releasever - Gluster #{ver} - Testing"
+default['yum']['centos-gluster-testing']['enabled'] = false
+default['yum']['centos-gluster-testing']['make_cache'] = true
+default['yum']['centos-gluster-testing']['managed'] = false
+default['yum']['centos-gluster-testing']['gpgcheck'] = false
+default['yum']['centos-gluster-testing']['baseurl'] =
+  "https://buildlogs.centos.org/centos/$releasever/storage/$basearch/gluster-#{ver}/"

--- a/attributes/centos-kernel.rb
+++ b/attributes/centos-kernel.rb
@@ -1,0 +1,8 @@
+default['yum']['centos-kernel']['repositoryid'] = 'centos-kernel'
+default['yum']['centos-kernel']['description'] = 'CentOS LTS Kernels for $basearch'
+default['yum']['centos-kernel']['enabled'] = false
+default['yum']['centos-kernel']['make_cache'] = true
+default['yum']['centos-kernel']['managed'] = false
+default['yum']['centos-kernel']['mirrorlist'] =
+  'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=kernel'
+default['yum']['centos-kernel']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever'

--- a/attributes/centos-nfs-ganesha.rb
+++ b/attributes/centos-nfs-ganesha.rb
@@ -1,0 +1,22 @@
+# centos-release-nfs-ganesha30 : CentOS 7
+# centos-release-nfs-ganesha30 : CentOS 8
+ver = node['yum-centos']['nfs_ganesha_version']
+
+default['yum']['centos-nfs-ganesha']['repositoryid'] = 'centos-nfs-ganesha'
+default['yum']['centos-nfs-ganesha']['description'] = "CentOS-$releasever - NFS Ganesha #{ver}"
+default['yum']['centos-nfs-ganesha']['enabled'] = false
+default['yum']['centos-nfs-ganesha']['make_cache'] = true
+default['yum']['centos-nfs-ganesha']['managed'] = false
+default['yum']['centos-nfs-ganesha']['mirrorlist'] =
+  "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=storage-nfsganesha-#{ver}"
+default['yum']['centos-nfs-ganesha']['gpgkey'] = 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Storage'
+# testing
+default['yum']['centos-nfs-ganesha-testing']['repositoryid'] = 'centos-nfs-ganesha-testing'
+default['yum']['centos-nfs-ganesha-testing']['description'] =
+  "CentOS-$releasever - NFS Ganesha #{ver} - Testing"
+default['yum']['centos-nfs-ganesha-testing']['enabled'] = false
+default['yum']['centos-nfs-ganesha-testing']['make_cache'] = true
+default['yum']['centos-nfs-ganesha-testing']['managed'] = false
+default['yum']['centos-nfs-ganesha-testing']['gpgcheck'] = false
+default['yum']['centos-nfs-ganesha-testing']['baseurl'] =
+  "https://buildlogs.centos.org/centos/$releasever/storage/$basearch/nfsganesha-#{ver}/"

--- a/attributes/centos-nfv-common.rb
+++ b/attributes/centos-nfv-common.rb
@@ -1,0 +1,18 @@
+# centos-release-nfv-common : CentOS 7 only
+default['yum']['centos-nfv-common']['repositoryid'] = 'centos-nfv-common'
+default['yum']['centos-nfv-common']['description'] = 'CentOS-$releasever - nfv common'
+default['yum']['centos-nfv-common']['enabled'] = false
+default['yum']['centos-nfv-common']['make_cache'] = true
+default['yum']['centos-nfv-common']['managed'] = false
+default['yum']['centos-nfv-common']['mirrorlist'] =
+  'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=nfv-common'
+default['yum']['centos-nfv-common']['gpgkey'] = 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-NFV'
+# testing
+default['yum']['centos-nfv-common-testing']['repositoryid'] = 'centos-nfv-common-testing'
+default['yum']['centos-nfv-common-testing']['description'] = 'CentOS-$releasever - nfv common - Testing'
+default['yum']['centos-nfv-common-testing']['enabled'] = false
+default['yum']['centos-nfv-common-testing']['make_cache'] = true
+default['yum']['centos-nfv-common-testing']['managed'] = false
+default['yum']['centos-nfv-common-testing']['gpgcheck'] = false
+default['yum']['centos-nfv-common-testing']['baseurl'] =
+  'https://buildlogs.centos.org/centos/$releasever/nfv/$basearch/nfv-common/'

--- a/attributes/centos-openshift-origin.rb
+++ b/attributes/centos-openshift-origin.rb
@@ -1,0 +1,30 @@
+# centos-release-openshift-origin311 : CentOS 7 only
+ver = node['yum-centos']['openshift_version']
+
+default['yum']['centos-openshift-origin']['repositoryid'] = 'centos-openshift-origin'
+default['yum']['centos-openshift-origin']['description'] = "CentOS-$releasever - OpenShift Origin #{ver}"
+default['yum']['centos-openshift-origin']['enabled'] = false
+default['yum']['centos-openshift-origin']['make_cache'] = true
+default['yum']['centos-openshift-origin']['managed'] = false
+default['yum']['centos-openshift-origin']['mirrorlist'] =
+  "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=paas-openshift-origin#{ver}"
+default['yum']['centos-openshift-origin']['gpgkey'] = 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-PaaS'
+# testing
+default['yum']['centos-openshift-origin-testing']['repositoryid'] = 'centos-openshift-origin-testing'
+default['yum']['centos-openshift-origin-testing']['description'] =
+  "CentOS-$releasever - OpenShift Origin #{ver} - Testing"
+default['yum']['centos-openshift-origin-testing']['enabled'] = false
+default['yum']['centos-openshift-origin-testing']['make_cache'] = true
+default['yum']['centos-openshift-origin-testing']['managed'] = false
+default['yum']['centos-openshift-origin-testing']['gpgcheck'] = false
+default['yum']['centos-openshift-origin-testing']['baseurl'] =
+  "https://buildlogs.centos.org/centos/$releasever/paas/$basearch/openshift-origin#{ver}/"
+# debuginfo
+default['yum']['centos-openshift-origin-debuginfo']['repositoryid'] = 'centos-openshift-origin-debuginfo'
+default['yum']['centos-openshift-origin-debuginfo']['description'] =
+  "CentOS-$releasever - OpenShift Origin #{ver} - DebugInfo"
+default['yum']['centos-openshift-origin-debuginfo']['enabled'] = false
+default['yum']['centos-openshift-origin-debuginfo']['make_cache'] = true
+default['yum']['centos-openshift-origin-debuginfo']['managed'] = false
+default['yum']['centos-openshift-origin-debuginfo']['baseurl'] =
+  'http://debuginfo.centos.org/centos/$releasever/paas/$basearch/'

--- a/attributes/centos-openstack.rb
+++ b/attributes/centos-openstack.rb
@@ -33,13 +33,3 @@ default['yum']['centos-openstack-debuginfo']['exclude'] = 'sip,PyQt4'
 default['yum']['centos-openstack-debuginfo']['baseurl'] =
   'http://debuginfo.centos.org/centos/$releasever/cloud/$basearch/'
 default['yum']['centos-openstack-debuginfo']['gpgkey'] = 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Cloud'
-# rdo-trunk-tested
-default['yum']['centos-openstack-trunk-tested']['repositoryid'] = 'centos-openstack-trunk-tested'
-default['yum']['centos-openstack-trunk-tested']['description'] = "OpenStack #{ver.capitalize} Trunk Tested"
-default['yum']['centos-openstack-trunk-tested']['enabled'] = false
-default['yum']['centos-openstack-trunk-tested']['make_cache'] = true
-default['yum']['centos-openstack-trunk-tested']['managed'] = false
-default['yum']['centos-openstack-trunk-tested']['gpgcheck'] = false
-default['yum']['centos-openstack-trunk-tested']['exclude'] = 'sip,PyQt4'
-default['yum']['centos-openstack-trunk-tested']['baseurl'] =
-  "https://trunk.rdoproject.org/centos$releasever-#{ver}/current-passed-ci/"

--- a/attributes/centos-openstack.rb
+++ b/attributes/centos-openstack.rb
@@ -1,0 +1,45 @@
+# centos-release-openstack-train  : CentOS 7
+# centos-release-openstack-ussuri : CentOS 8
+ver = node['yum-centos']['openstack_version']
+
+default['yum']['centos-openstack']['repositoryid'] = 'centos-openstack'
+default['yum']['centos-openstack']['description'] =
+  "CentOS-$releasever - OpenStack #{ver.capitalize}"
+default['yum']['centos-openstack']['enabled'] = false
+default['yum']['centos-openstack']['make_cache'] = true
+default['yum']['centos-openstack']['managed'] = false
+default['yum']['centos-openstack']['exclude'] = 'sip,PyQt4'
+default['yum']['centos-openstack']['mirrorlist'] =
+  "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=cloud-openstack-#{ver}"
+default['yum']['centos-openstack']['gpgkey'] = 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Cloud'
+# testing
+default['yum']['centos-openstack-testing']['repositoryid'] = 'centos-openstack-testing'
+default['yum']['centos-openstack-testing']['description'] = "CentOS-$releasever - OpenStack #{ver} - Testing"
+default['yum']['centos-openstack-testing']['enabled'] = false
+default['yum']['centos-openstack-testing']['make_cache'] = true
+default['yum']['centos-openstack-testing']['managed'] = false
+default['yum']['centos-openstack-testing']['gpgcheck'] = false
+default['yum']['centos-openstack-testing']['exclude'] = 'sip,PyQt4'
+default['yum']['centos-openstack-testing']['baseurl'] =
+  "https://buildlogs.centos.org/centos/$releasever/cloud/$basearch/openstack-#{ver}/"
+# debuginfo
+default['yum']['centos-openstack-debuginfo']['repositoryid'] = 'centos-openstack-debuginfo'
+default['yum']['centos-openstack-debuginfo']['description'] =
+  "CentOS-$releasever - OpenStack #{ver.capitalize} - Debuginfo"
+default['yum']['centos-openstack-debuginfo']['enabled'] = false
+default['yum']['centos-openstack-debuginfo']['make_cache'] = true
+default['yum']['centos-openstack-debuginfo']['managed'] = false
+default['yum']['centos-openstack-debuginfo']['exclude'] = 'sip,PyQt4'
+default['yum']['centos-openstack-debuginfo']['baseurl'] =
+  'http://debuginfo.centos.org/centos/$releasever/cloud/$basearch/'
+default['yum']['centos-openstack-debuginfo']['gpgkey'] = 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Cloud'
+# rdo-trunk-tested
+default['yum']['centos-openstack-trunk-tested']['repositoryid'] = 'centos-openstack-trunk-tested'
+default['yum']['centos-openstack-trunk-tested']['description'] = "OpenStack #{ver.capitalize} Trunk Tested"
+default['yum']['centos-openstack-trunk-tested']['enabled'] = false
+default['yum']['centos-openstack-trunk-tested']['make_cache'] = true
+default['yum']['centos-openstack-trunk-tested']['managed'] = false
+default['yum']['centos-openstack-trunk-tested']['gpgcheck'] = false
+default['yum']['centos-openstack-trunk-tested']['exclude'] = 'sip,PyQt4'
+default['yum']['centos-openstack-trunk-tested']['baseurl'] =
+  "https://trunk.rdoproject.org/centos$releasever-#{ver}/current-passed-ci/"

--- a/attributes/centos-opstools.rb
+++ b/attributes/centos-opstools.rb
@@ -1,0 +1,21 @@
+# centos-release-opstools : CentOS 7
+# centos-release-opstools : CentOS 8
+ver = node['yum-centos']['opstools_version']
+
+default['yum']['centos-opstools']['repositoryid'] = 'centos-opstools'
+default['yum']['centos-opstools']['description'] = 'CentOS-$releasever - OpsTools'
+default['yum']['centos-opstools']['enabled'] = false
+default['yum']['centos-opstools']['make_cache'] = true
+default['yum']['centos-opstools']['managed'] = false
+default['yum']['centos-opstools']['mirrorlist'] =
+  "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=opstools#{ver}"
+default['yum']['centos-opstools']['gpgkey'] = 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-OpsTools'
+# testing
+default['yum']['centos-opstools-testing']['repositoryid'] = 'centos-opstools-testing'
+default['yum']['centos-opstools-testing']['description'] = 'CentOS-$releasever - OpsTools - Testing'
+default['yum']['centos-opstools-testing']['enabled'] = false
+default['yum']['centos-opstools-testing']['make_cache'] = true
+default['yum']['centos-opstools-testing']['managed'] = false
+default['yum']['centos-opstools-testing']['gpgcheck'] = false
+default['yum']['centos-opstools-testing']['baseurl'] =
+  "https://buildlogs.centos.org/centos/$releasever/opstools/$basearch/#{ver.delete_prefix('-')}"

--- a/attributes/centos-ovirt.rb
+++ b/attributes/centos-ovirt.rb
@@ -1,0 +1,29 @@
+# centos-release-ovirt43 : CentOS 7 Only
+ver = node['yum-centos']['ovirt_version']
+
+default['yum']['centos-ovirt']['repositoryid'] = 'centos-ovirt'
+default['yum']['centos-ovirt']['description'] = "CentOS-$releasever - oVirt #{ver}"
+default['yum']['centos-ovirt']['enabled'] = false
+default['yum']['centos-ovirt']['make_cache'] = true
+default['yum']['centos-ovirt']['managed'] = false
+default['yum']['centos-ovirt']['mirrorlist'] =
+  "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=virt-ovirt-#{ver}"
+default['yum']['centos-ovirt']['gpgkey'] = 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Virtualization'
+# testing
+default['yum']['centos-ovirt-testing']['repositoryid'] = 'centos-ovirt-testing'
+default['yum']['centos-ovirt-testing']['description'] = "CentOS-$releasever - oVirt #{ver} - Testing"
+default['yum']['centos-ovirt-testing']['enabled'] = false
+default['yum']['centos-ovirt-testing']['make_cache'] = true
+default['yum']['centos-ovirt-testing']['managed'] = false
+default['yum']['centos-ovirt-testing']['gpgcheck'] = false
+default['yum']['centos-ovirt-testing']['baseurl'] =
+  "https://buildlogs.centos.org/centos/$releasever/virt/$basearch/ovirt-#{ver}/"
+# debuginfo
+default['yum']['centos-ovirt-debuginfo']['repositoryid'] = 'centos-ovirt-debuginfo'
+default['yum']['centos-ovirt-debuginfo']['description'] = "CentOS-$releasever - oVirt #{ver} - Debuginfo"
+default['yum']['centos-ovirt-debuginfo']['enabled'] = false
+default['yum']['centos-ovirt-debuginfo']['make_cache'] = true
+default['yum']['centos-ovirt-debuginfo']['managed'] = false
+default['yum']['centos-ovirt-debuginfo']['baseurl'] = 'http://debuginfo.centos.org/centos/$releasever/virt/$basearch/'
+default['yum']['centos-ovirt-debuginfo']['gpgkey'] =
+  'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Virtualization'

--- a/attributes/centos-qemu-ev.rb
+++ b/attributes/centos-qemu-ev.rb
@@ -1,0 +1,18 @@
+# centos-release-qemu-ev : CentOS 7 only
+default['yum']['centos-qemu-ev']['repositoryid'] = 'centos-qemu-ev'
+default['yum']['centos-qemu-ev']['description'] = 'CentOS-$releasever - QEMU EV'
+default['yum']['centos-qemu-ev']['enabled'] = false
+default['yum']['centos-qemu-ev']['make_cache'] = true
+default['yum']['centos-qemu-ev']['managed'] = false
+default['yum']['centos-qemu-ev']['mirrorlist'] =
+  'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=virt-kvm-common'
+default['yum']['centos-qemu-ev']['gpgkey'] = 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Virtualization'
+# testing
+default['yum']['centos-qemu-ev-testing']['repositoryid'] = 'centos-qemu-ev-testing'
+default['yum']['centos-qemu-ev-testing']['description'] = 'CentOS-$releasever - QEMU EV - Testing'
+default['yum']['centos-qemu-ev-testing']['enabled'] = false
+default['yum']['centos-qemu-ev-testing']['make_cache'] = true
+default['yum']['centos-qemu-ev-testing']['managed'] = false
+default['yum']['centos-qemu-ev-testing']['gpgcheck'] = false
+default['yum']['centos-qemu-ev-testing']['baseurl'] =
+  'https://buildlogs.centos.org/centos/$releasever/virt/$basearch/kvm-common/'

--- a/attributes/centos-qpid-proton.rb
+++ b/attributes/centos-qpid-proton.rb
@@ -1,0 +1,31 @@
+# centos-release-qpid-proton : CentOS 8 Only
+default['yum']['centos-qpid-proton']['repositoryid'] = 'centos-qpid-proton'
+default['yum']['centos-qpid-proton']['description'] = 'CentOS-$releasever - QPID Proton'
+default['yum']['centos-qpid-proton']['enabled'] = false
+default['yum']['centos-qpid-proton']['make_cache'] = true
+default['yum']['centos-qpid-proton']['managed'] = false
+default['yum']['centos-qpid-proton']['mirrorlist'] =
+  'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=messaging-qpid-proton'
+# The Messaging SIG is currently in planning/onboarding so the key only exists in the release package or the git repo
+# https://wiki.centos.org/SpecialInterestGroup/Messaging
+default['yum']['centos-qpid-proton']['gpgkey'] =
+  'https://git.centos.org/rpms/centos-release-messaging/raw/c8-sig-messaging/f/SOURCES/RPM-GPG-KEY-CentOS-SIG-Messaging'
+# testing
+default['yum']['centos-qpid-proton-testing']['repositoryid'] = 'centos-qpid-proton-testing'
+default['yum']['centos-qpid-proton-testing']['description'] = 'CentOS-$releasever - QPID Proton - Testing'
+default['yum']['centos-qpid-proton-testing']['enabled'] = false
+default['yum']['centos-qpid-proton-testing']['make_cache'] = true
+default['yum']['centos-qpid-proton-testing']['managed'] = false
+default['yum']['centos-qpid-proton-testing']['gpgcheck'] = false
+default['yum']['centos-qpid-proton-testing']['baseurl'] =
+  'https://buildlogs.centos.org/centos/$releasever/messaging/$basearch/qpid-proton'
+# debuginfo
+default['yum']['centos-qpid-proton-debuginfo']['repositoryid'] = 'centos-qpid-proton-debuginfo'
+default['yum']['centos-qpid-proton-debuginfo']['description'] = 'CentOS-$releasever - QPID Proton - Debuginfo'
+default['yum']['centos-qpid-proton-debuginfo']['enabled'] = false
+default['yum']['centos-qpid-proton-debuginfo']['make_cache'] = true
+default['yum']['centos-qpid-proton-debuginfo']['managed'] = false
+default['yum']['centos-qpid-proton-debuginfo']['baseurl'] =
+  'http://debuginfo.centos.org/centos/$releasever/messaging/$basearch/'
+default['yum']['centos-qpid-proton-debuginfo']['gpgkey'] =
+  'https://git.centos.org/rpms/centos-release-messaging/raw/c8-sig-messaging/f/SOURCES/RPM-GPG-KEY-CentOS-SIG-Messaging'

--- a/attributes/centos-rabbitmq.rb
+++ b/attributes/centos-rabbitmq.rb
@@ -1,0 +1,33 @@
+# centos-release-rabbitmq-38 : CentOS 8 Only
+ver = node['yum-centos']['rabbitmq_version']
+
+default['yum']['centos-rabbitmq']['repositoryid'] = 'centos-rabbitmq'
+default['yum']['centos-rabbitmq']['description'] = "CentOS-$releasever - RabbitMQ #{ver}"
+default['yum']['centos-rabbitmq']['enabled'] = false
+default['yum']['centos-rabbitmq']['make_cache'] = true
+default['yum']['centos-rabbitmq']['managed'] = false
+default['yum']['centos-rabbitmq']['mirrorlist'] =
+  "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=messaging-rabbitmq-#{ver}"
+# The Messaging SIG is currently in planning/onboarding so the key only exists in the release package or the git repo
+# https://wiki.centos.org/SpecialInterestGroup/Messaging
+default['yum']['centos-rabbitmq']['gpgkey'] =
+  'https://git.centos.org/rpms/centos-release-messaging/raw/c8-sig-messaging/f/SOURCES/RPM-GPG-KEY-CentOS-SIG-Messaging'
+# testing
+default['yum']['centos-rabbitmq-testing']['repositoryid'] = 'centos-rabbitmq-testing'
+default['yum']['centos-rabbitmq-testing']['description'] = "CentOS-$releasever - RabbitMQ #{ver} - Testing"
+default['yum']['centos-rabbitmq-testing']['enabled'] = false
+default['yum']['centos-rabbitmq-testing']['make_cache'] = true
+default['yum']['centos-rabbitmq-testing']['managed'] = false
+default['yum']['centos-rabbitmq-testing']['gpgcheck'] = false
+default['yum']['centos-rabbitmq-testing']['baseurl'] =
+  "https://buildlogs.centos.org/centos/$releasever/messaging/$basearch/rabbitmq-#{ver}/"
+# debuginfo
+default['yum']['centos-rabbitmq-debuginfo']['repositoryid'] = 'centos-rabbitmq-debuginfo'
+default['yum']['centos-rabbitmq-debuginfo']['description'] = "CentOS-$releasever - RabbitMQ #{ver} - Debuginfo"
+default['yum']['centos-rabbitmq-debuginfo']['enabled'] = false
+default['yum']['centos-rabbitmq-debuginfo']['make_cache'] = true
+default['yum']['centos-rabbitmq-debuginfo']['managed'] = false
+default['yum']['centos-rabbitmq-debuginfo']['baseurl'] =
+  'http://debuginfo.centos.org/centos/$releasever/messaging/$basearch/'
+default['yum']['centos-rabbitmq-debuginfo']['gpgkey'] =
+  'https://git.centos.org/rpms/centos-release-messaging/raw/c8-sig-messaging/f/SOURCES/RPM-GPG-KEY-CentOS-SIG-Messaging'

--- a/attributes/centos-sclo-rh.rb
+++ b/attributes/centos-sclo-rh.rb
@@ -1,0 +1,28 @@
+# centos-release-scl-rh : CentOS 6
+# centos-release-scl-rh : CentOS 7
+default['yum']['centos-sclo-rh']['repositoryid'] = 'centos-sclo-rh'
+default['yum']['centos-sclo-rh']['description'] = 'CentOS-$releasever - SCLo rh'
+default['yum']['centos-sclo-rh']['enabled'] = false
+default['yum']['centos-sclo-rh']['make_cache'] = true
+default['yum']['centos-sclo-rh']['managed'] = false
+default['yum']['centos-sclo-rh']['mirrorlist'] =
+  'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=sclo-rh'
+default['yum']['centos-sclo-rh']['gpgkey'] = 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-SCLo'
+# testing
+default['yum']['centos-sclo-rh-testing']['repositoryid'] = 'centos-sclo-rh-testing'
+default['yum']['centos-sclo-rh-testing']['description'] = 'CentOS-$releasever - SCLo rh - Testing'
+default['yum']['centos-sclo-rh-testing']['enabled'] = false
+default['yum']['centos-sclo-rh-testing']['make_cache'] = true
+default['yum']['centos-sclo-rh-testing']['managed'] = false
+default['yum']['centos-sclo-rh-testing']['gpgcheck'] = false
+default['yum']['centos-sclo-rh-testing']['baseurl'] =
+  'https://buildlogs.centos.org/centos/$releasever/sclo/$basearch/rh/'
+# debuginfo
+default['yum']['centos-sclo-rh-debuginfo']['repositoryid'] = 'centos-sclo-rh-debuginfo'
+default['yum']['centos-sclo-rh-debuginfo']['description'] = 'CentOS-$releasever - SCLo rh - Debuginfo'
+default['yum']['centos-sclo-rh-debuginfo']['enabled'] = false
+default['yum']['centos-sclo-rh-debuginfo']['make_cache'] = true
+default['yum']['centos-sclo-rh-debuginfo']['managed'] = false
+default['yum']['centos-sclo-rh-debuginfo']['baseurl'] =
+  'http://debuginfo.centos.org/centos/$releasever/sclo/$basearch/'
+default['yum']['centos-sclo-rh-debuginfo']['gpgkey'] = 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-SCLo'

--- a/attributes/centos-sclo.rb
+++ b/attributes/centos-sclo.rb
@@ -1,0 +1,27 @@
+# centos-release-scl : CentOS 6
+# centos-release-scl : CentOS 7
+default['yum']['centos-sclo']['repositoryid'] = 'centos-sclo'
+default['yum']['centos-sclo']['description'] = 'CentOS-$releasever - SCLo sclo'
+default['yum']['centos-sclo']['enabled'] = false
+default['yum']['centos-sclo']['make_cache'] = true
+default['yum']['centos-sclo']['managed'] = false
+default['yum']['centos-sclo']['mirrorlist'] =
+  'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=sclo-sclo'
+default['yum']['centos-sclo']['gpgkey'] = 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-SCLo'
+# testing
+default['yum']['centos-sclo-testing']['repositoryid'] = 'centos-sclo-testing'
+default['yum']['centos-sclo-testing']['description'] = 'CentOS-$releasever - SCLo sclo - Testing'
+default['yum']['centos-sclo-testing']['enabled'] = false
+default['yum']['centos-sclo-testing']['make_cache'] = true
+default['yum']['centos-sclo-testing']['managed'] = false
+default['yum']['centos-sclo-testing']['gpgcheck'] = false
+default['yum']['centos-sclo-testing']['baseurl'] =
+  'https://buildlogs.centos.org/centos/$releasever/sclo/$basearch/sclo/'
+# debuginfo
+default['yum']['centos-sclo-debuginfo']['repositoryid'] = 'centos-sclo-debuginfo'
+default['yum']['centos-sclo-debuginfo']['description'] = 'CentOS-$releasever - SCLo sclo - Debuginfo'
+default['yum']['centos-sclo-debuginfo']['enabled'] = false
+default['yum']['centos-sclo-debuginfo']['make_cache'] = true
+default['yum']['centos-sclo-debuginfo']['managed'] = false
+default['yum']['centos-sclo-debuginfo']['baseurl'] = 'http://debuginfo.centos.org/centos/$releasever/sclo/$basearch/'
+default['yum']['centos-sclo-debuginfo']['gpgkey'] = 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-SCLo'

--- a/attributes/centos-virt-xen.rb
+++ b/attributes/centos-virt-xen.rb
@@ -1,0 +1,21 @@
+# centos-release-xen-410 : CentOS 6
+# centos-release-xen-412 : CentOS 7
+ver = node['yum-centos']['virt_xen_version']
+
+default['yum']['centos-virt-xen']['repositoryid'] = 'centos-virt-xen'
+default['yum']['centos-virt-xen']['description'] = 'CentOS-$releasever - xen'
+default['yum']['centos-virt-xen']['enabled'] = false
+default['yum']['centos-virt-xen']['make_cache'] = true
+default['yum']['centos-virt-xen']['managed'] = false
+default['yum']['centos-virt-xen']['mirrorlist'] =
+  "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=virt-xen-#{ver}"
+default['yum']['centos-virt-xen']['gpgkey'] = 'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Virtualization'
+# testing
+default['yum']['centos-virt-xen-testing']['repositoryid'] = 'centos-virt-xen-testing'
+default['yum']['centos-virt-xen-testing']['description'] = 'CentOS-$releasever - xen - Testing'
+default['yum']['centos-virt-xen-testing']['enabled'] = false
+default['yum']['centos-virt-xen-testing']['make_cache'] = true
+default['yum']['centos-virt-xen-testing']['managed'] = false
+default['yum']['centos-virt-xen-testing']['gpgcheck'] = false
+default['yum']['centos-virt-xen-testing']['baseurl'] =
+  "https://buildlogs.centos.org/centos/$releasever/virt/$basearch/xen-#{ver}"

--- a/attributes/contrib.rb
+++ b/attributes/contrib.rb
@@ -1,8 +1,8 @@
 default['yum']['contrib']['repositoryid'] = 'contrib'
-default['yum']['contrib']['description'] = "CentOS-#{node['platform_version'].to_i} - Contrib"
-default['yum']['contrib']['mirrorlist'] = "http://mirrorlist.centos.org/?release=#{node['platform_version'].to_i}&arch=$basearch&repo=contrib"
+default['yum']['contrib']['description'] = 'CentOS-$releasever - Contrib'
+default['yum']['contrib']['mirrorlist'] = 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=contrib'
 default['yum']['contrib']['enabled'] = false
 default['yum']['contrib']['make_cache'] = true
 default['yum']['contrib']['managed'] = false
 default['yum']['contrib']['gpgcheck'] = true
-default['yum']['contrib']['gpgkey'] = "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-#{node['platform_version'].to_i}"
+default['yum']['contrib']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever'

--- a/attributes/cr.rb
+++ b/attributes/cr.rb
@@ -1,13 +1,13 @@
 default['yum']['cr']['repositoryid'] = 'cr'
-default['yum']['cr']['description'] = "CentOS-#{node['platform_version'].to_i} - Continuous Release"
+default['yum']['cr']['description'] = 'CentOS-$releasever - Continuous Release'
 default['yum']['cr']['enabled'] = false
 default['yum']['cr']['make_cache'] = true
 default['yum']['cr']['managed'] = false
 default['yum']['cr']['gpgcheck'] = true
-if node['platform_version'].to_i >= 8
-  default['yum']['cr']['baseurl'] = "http://mirror.centos.org/$contentdir/#{node['platform_version'].to_i}/cr/$basearch/os/"
-  default['yum']['cr']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial'
-else
-  default['yum']['cr']['mirrorlist'] = "http://mirrorlist.centos.org/?release=#{node['platform_version'].to_i}&arch=$basearch&repo=cr"
-  default['yum']['cr']['gpgkey'] = "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-#{node['platform_version'].to_i}"
-end
+default['yum']['cr']['mirrorlist'] = 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=cr'
+default['yum']['cr']['gpgkey'] =
+  if node['platform_version'].to_i >= 8
+    'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial'
+  else
+    'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever'
+  end

--- a/attributes/debuginfo.rb
+++ b/attributes/debuginfo.rb
@@ -1,6 +1,6 @@
 default['yum']['debuginfo']['repositoryid'] = 'debuginfo'
-default['yum']['debuginfo']['description'] = "CentOS-#{node['platform_version'].to_i} - Debuginfo"
-default['yum']['debuginfo']['baseurl'] = "http://debuginfo.centos.org/#{node['platform_version'].to_i}/$basearch/"
+default['yum']['debuginfo']['description'] = 'CentOS-$releasever - Debuginfo'
+default['yum']['debuginfo']['baseurl'] = 'http://debuginfo.centos.org/$releasever/$basearch/'
 default['yum']['debuginfo']['enabled'] = false
 default['yum']['debuginfo']['make_cache'] = true
 default['yum']['debuginfo']['managed'] = false
@@ -9,5 +9,5 @@ default['yum']['debuginfo']['gpgkey'] =
   if node['platform_version'].to_i >= 8
     'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial'
   else
-    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-#{node['platform_version'].to_i}"
+    'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever'
   end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,11 +1,156 @@
 default['yum-centos']['repos'] =
   value_for_platform(%w(centos redhat xenserver) =>
     {
-      # TODO: Add debuginfo and cr repos for EL8 when repos are ready
-      '>= 8.0' => %w(base appstream powertools extras centosplus fasttrack debuginfo),
-      '~> 7.0' => %w(base updates extras centosplus fasttrack debuginfo cr),
-      '< 7.0' => %w(base updates extras centosplus fasttrack debuginfo contrib),
+      # NOTE: Ensure primary OS repos are listed first
+      '>= 8.0' =>
+        %w(
+          base
+          appstream
+          powertools
+          extras
+          centosplus
+          fasttrack
+          debuginfo
+          cr
+          highavailability
+          centos-ansible
+          centos-ansible-testing
+          centos-ansible-debuginfo
+          centos-ceph
+          centos-ceph-testing
+          centos-gluster
+          centos-gluster-testing
+          centos-nfs-ganesha
+          centos-nfs-ganesha-testing
+          centos-openstack
+          centos-openstack-testing
+          centos-openstack-debuginfo
+          centos-opstools
+          centos-opstools-testing
+          centos-qpid-proton
+          centos-qpid-proton-testing
+          centos-qpid-proton-debuginfo
+          centos-rabbitmq
+          centos-rabbitmq-testing
+          centos-rabbitmq-debuginfo
+        ),
+      '~> 7.0' =>
+        %w(
+          base
+          updates
+          extras
+          centosplus
+          fasttrack
+          debuginfo
+          cr
+          centos-kernel
+          centos-ansible
+          centos-ansible-testing
+          centos-ansible-debuginfo
+          centos-azure
+          centos-azure-testing
+          centos-ceph
+          centos-ceph-testing
+          centos-dotnet
+          centos-fdio
+          centos-fdio-testing
+          centos-nfv-common
+          centos-nfv-common-testing
+          centos-gluster
+          centos-gluster-testing
+          centos-nfs-ganesha
+          centos-nfs-ganesha-testing
+          centos-openshift-origin
+          centos-openshift-origin-testing
+          centos-openshift-origin-debuginfo
+          centos-openstack
+          centos-openstack-testing
+          centos-openstack-debuginfo
+          centos-openstack-trunk-tested
+          centos-opstools
+          centos-opstools-testing
+          centos-ovirt
+          centos-ovirt-testing
+          centos-ovirt-debuginfo
+          centos-qemu-ev
+          centos-qemu-ev-testing
+          centos-sclo
+          centos-sclo-testing
+          centos-sclo-debuginfo
+          centos-sclo-rh
+          centos-sclo-rh-testing
+          centos-sclo-rh-debuginfo
+          centos-virt-xen
+          centos-virt-xen-testing
+        ),
+      '< 7.0' =>
+        %w(
+          base
+          updates
+          extras
+          centosplus
+          fasttrack
+          debuginfo
+          cr
+          contrib
+          centos-azure
+          centos-azure-testing
+          centos-gluster
+          centos-gluster-testing
+          centos-sclo
+          centos-sclo-testing
+          centos-sclo-debuginfo
+          centos-sclo-rh
+          centos-sclo-rh-testing
+          centos-sclo-rh-debuginfo
+          centos-virt-xen
+          centos-virt-xen-testing
+        ),
     })
+# Vault only provides binary packages for the previous release
+default['yum-centos']['vault_release'] =
+  value_for_platform(%w(centos redhat xenserver) =>
+  {
+      '>= 8.0' => '8.0.1905',
+      '~> 7.0' => '7.7.1908',
+      '< 7.0' => '6.9',
+  })
 
-# NOTE: if set to false, repositories starting with CentOS-SCLo-* won't be deleted
-default['yum-centos']['keep_scl_repositories'] = true
+# SIG repo versions
+default['yum-centos']['ansible_version'] = '29'
+default['yum-centos']['ceph_version'] =
+  value_for_platform(%w(centos redhat xenserver) =>
+  {
+      '>= 8.0' => 'octopus',
+      '~> 7.0' => 'nautilus',
+      '< 7.0' => '',
+  })
+default['yum-centos']['gluster_version'] = '7'
+default['yum-centos']['nfs_ganesha_version'] =
+  value_for_platform(%w(centos redhat xenserver) =>
+  {
+      '>= 8.0' => '3',
+      '~> 7.0' => '30',
+  })
+default['yum-centos']['openshift_version'] = '311'
+default['yum-centos']['openstack_version'] =
+  value_for_platform(%w(centos redhat xenserver) =>
+  {
+      '>= 8.0' => 'ussuri',
+      '~> 7.0' => 'train',
+      '< 7.0' => '',
+  })
+default['yum-centos']['opstools_version'] =
+  value_for_platform(%w(centos redhat xenserver) =>
+  {
+      '>= 8.0' => '-collectd-5',
+      '< 8.0' => '',
+  })
+default['yum-centos']['ovirt_version'] = '4.3'
+default['yum-centos']['rabbitmq_version'] = '38'
+default['yum-centos']['virt_xen_version'] =
+  value_for_platform(%w(centos redhat xenserver) =>
+  {
+      '~> 7.0' => '412',
+      '< 7.0' => '410',
+  })

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -66,7 +66,6 @@ default['yum-centos']['repos'] =
           centos-openstack
           centos-openstack-testing
           centos-openstack-debuginfo
-          centos-openstack-trunk-tested
           centos-opstools
           centos-opstools-testing
           centos-ovirt

--- a/attributes/extras.rb
+++ b/attributes/extras.rb
@@ -1,6 +1,6 @@
 default['yum']['extras']['repositoryid'] = 'extras'
-default['yum']['extras']['description'] = "CentOS-#{node['platform_version'].to_i} - Extras"
-default['yum']['extras']['mirrorlist'] = "http://mirrorlist.centos.org/?release=#{node['platform_version'].to_i}&arch=$basearch&repo=extras&infra=$infra"
+default['yum']['extras']['description'] = 'CentOS-$releasever - Extras'
+default['yum']['extras']['mirrorlist'] = 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras'
 default['yum']['extras']['enabled'] = true
 default['yum']['extras']['make_cache'] = true
 default['yum']['extras']['managed'] = true
@@ -9,5 +9,5 @@ default['yum']['extras']['gpgkey'] =
   if node['platform_version'].to_i >= 8
     'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial'
   else
-    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-#{node['platform_version'].to_i}"
+    'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever'
   end

--- a/attributes/fasttrack.rb
+++ b/attributes/fasttrack.rb
@@ -1,6 +1,6 @@
 default['yum']['fasttrack']['repositoryid'] = 'fasttrack'
-default['yum']['fasttrack']['description'] = "CentOS-#{node['platform_version'].to_i} - fasttrack"
-default['yum']['fasttrack']['mirrorlist'] = "http://mirrorlist.centos.org/?release=#{node['platform_version'].to_i}&arch=$basearch&repo=fasttrack&infra=$infra"
+default['yum']['fasttrack']['description'] = 'CentOS-$releasever - fasttrack'
+default['yum']['fasttrack']['mirrorlist'] = 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=fasttrack'
 default['yum']['fasttrack']['enabled'] = false
 default['yum']['fasttrack']['make_cache'] = true
 default['yum']['fasttrack']['managed'] = false
@@ -9,5 +9,5 @@ default['yum']['fasttrack']['gpgkey'] =
   if node['platform_version'].to_i >= 8
     'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial'
   else
-    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-#{node['platform_version'].to_i}"
+    'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever'
   end

--- a/attributes/highavailability.rb
+++ b/attributes/highavailability.rb
@@ -1,0 +1,7 @@
+default['yum']['highavailability']['repositoryid'] = 'highavailability'
+default['yum']['highavailability']['description'] = 'CentOS-$releasever - HA'
+default['yum']['highavailability']['enabled'] = false
+default['yum']['highavailability']['make_cache'] = true
+default['yum']['highavailability']['managed'] = false
+default['yum']['highavailability']['mirrorlist'] = 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=HighAvailability'
+default['yum']['highavailability']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial'

--- a/attributes/plus.rb
+++ b/attributes/plus.rb
@@ -1,6 +1,6 @@
 default['yum']['centosplus']['repositoryid'] = 'centosplus'
-default['yum']['centosplus']['description'] = "CentOS-#{node['platform_version'].to_i} - Centosplus"
-default['yum']['centosplus']['mirrorlist'] = "http://mirrorlist.centos.org/?release=#{node['platform_version'].to_i}&arch=$basearch&repo=centosplus&infra=$infra"
+default['yum']['centosplus']['description'] = 'CentOS-$releasever - Centosplus'
+default['yum']['centosplus']['mirrorlist'] = 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=centosplus'
 default['yum']['centosplus']['enabled'] = false
 default['yum']['centosplus']['make_cache'] = true
 default['yum']['centosplus']['managed'] = false
@@ -9,5 +9,5 @@ default['yum']['centosplus']['gpgkey'] =
   if node['platform_version'].to_i >= 8
     'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial'
   else
-    "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-#{node['platform_version'].to_i}"
+    'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever'
   end

--- a/attributes/powertools.rb
+++ b/attributes/powertools.rb
@@ -3,5 +3,5 @@ default['yum']['powertools']['description'] = "CentOS-#{node['platform_version']
 default['yum']['powertools']['enabled'] = false
 default['yum']['powertools']['make_cache'] = true
 default['yum']['powertools']['managed'] = false
-default['yum']['powertools']['mirrorlist'] = "http://mirrorlist.centos.org/?release=#{node['platform_version'].to_i}&arch=$basearch&repo=PowerTools&infra=$infra"
+default['yum']['powertools']['mirrorlist'] = "http://mirrorlist.centos.org/?release=#{node['platform_version'].to_i}&arch=$basearch&repo=PowerTools"
 default['yum']['powertools']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial'

--- a/attributes/updates.rb
+++ b/attributes/updates.rb
@@ -1,8 +1,8 @@
 default['yum']['updates']['repositoryid'] = 'updates'
-default['yum']['updates']['description'] = "CentOS-#{node['platform_version'].to_i} - Updates"
-default['yum']['updates']['mirrorlist'] = "http://mirrorlist.centos.org/?release=#{node['platform_version'].to_i}&arch=$basearch&repo=updates"
+default['yum']['updates']['description'] = 'CentOS-$releasever - Updates'
+default['yum']['updates']['mirrorlist'] = 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates'
 default['yum']['updates']['enabled'] = true
 default['yum']['updates']['make_cache'] = true
 default['yum']['updates']['managed'] = true
 default['yum']['updates']['gpgcheck'] = true
-default['yum']['updates']['gpgkey'] = "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-#{node['platform_version'].to_i}"
+default['yum']['updates']['gpgkey'] = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever'

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -18,7 +18,9 @@ suites:
   - name: default
     run_list:
       - recipe[yum-centos::default]
-
+  - name: vault
+    run_list:
+      - recipe[yum-centos::vault]
   - name: all
     run_list:
       - recipe[yum-centos::default]
@@ -40,5 +42,143 @@ suites:
           managed: true
           enabled: true
         debuginfo:
+          managed: true
+          enabled: true
+        centos-ansible:
+          managed: true
+          enabled: true
+        centos-ansible-testing:
+          managed: true
+          enabled: true
+        centos-ansible-debuginfo:
+          managed: true
+          enabled: true
+        centos-azure:
+          managed: true
+          enabled: true
+        centos-azure-testing:
+          managed: true
+          enabled: true
+        centos-ceph:
+          managed: true
+          enabled: true
+        centos-ceph-testing:
+          managed: true
+          enabled: true
+        centos-dotnet:
+          managed: true
+          enabled: true
+        centos-fdio:
+          managed: true
+          enabled: true
+        centos-fdio-testing:
+          managed: true
+          enabled: true
+        centos-kernel:
+          managed: true
+          enabled: true
+        centos-gluster:
+          managed: true
+          enabled: true
+        centos-gluster-testing:
+          managed: true
+          enabled: true
+        highavailability:
+          managed: true
+          enabled: true
+        centos-nfs-ganesha:
+          managed: true
+          enabled: true
+        centos-nfs-ganesha-testing:
+          managed: true
+          enabled: true
+        centos-nfv-common:
+          managed: true
+          enabled: true
+        centos-nfv-common-testing:
+          managed: true
+          enabled: true
+        centos-openshift-origin:
+          managed: true
+          enabled: true
+        centos-openshift-origin-testing:
+          managed: true
+          enabled: true
+        centos-openshift-origin-debuginfo:
+          managed: true
+          enabled: true
+        centos-openstack:
+          managed: true
+          enabled: true
+        centos-openstack-testing:
+          managed: true
+          enabled: true
+        centos-openstack-debuginfo:
+          managed: true
+          enabled: true
+        centos-openstack-trunk-tested:
+          managed: true
+          enabled: true
+        centos-opstools:
+          managed: true
+          enabled: true
+        centos-opstools-testing:
+          managed: true
+          enabled: true
+        centos-ovirt:
+          managed: true
+          enabled: true
+        centos-ovirt-testing:
+          managed: true
+          enabled: true
+        centos-ovirt-debuginfo:
+          managed: true
+          enabled: true
+        centos-qemu-ev:
+          managed: true
+          enabled: true
+        centos-qemu-ev-testing:
+          managed: true
+          enabled: true
+        centos-qpid-proton:
+          managed: true
+          enabled: true
+        centos-qpid-proton-testing:
+          managed: true
+          enabled: true
+        centos-qpid-proton-debuginfo:
+          managed: true
+          enabled: true
+        centos-rabbitmq:
+          managed: true
+          enabled: true
+        centos-rabbitmq-testing:
+          managed: true
+          enabled: true
+        centos-rabbitmq-debuginfo:
+          managed: true
+          enabled: true
+        centos-sclo:
+          managed: true
+          enabled: true
+        centos-sclo-testing:
+          managed: true
+          enabled: true
+        centos-sclo-debuginfo:
+          managed: true
+          enabled: true
+        centos-sclo-rh:
+          managed: true
+          enabled: true
+        centos-sclo-rh-testing:
+          managed: true
+          enabled: true
+        centos-sclo-rh-debuginfo:
+          managed: true
+          enabled: true
+        centos-virt-xen:
+          managed: true
+          enabled: true
+        centos-virt-xen-testing:
           managed: true
           enabled: true

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -116,9 +116,6 @@ suites:
         centos-openstack-debuginfo:
           managed: true
           enabled: true
-        centos-openstack-trunk-tested:
-          managed: true
-          enabled: true
         centos-opstools:
           managed: true
           enabled: true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,13 +33,12 @@ ruby_block 'xenserver $releasever' do
   end
 end
 
-repositories_to_delete = if node['yum-centos']['keep_scl_repositories']
-                           ::Dir['/etc/yum.repos.d/CentOS-*'].reject { |repo| repo.include?('CentOS-SCLo-') }
-                         else
-                           ::Dir['/etc/yum.repos.d/CentOS-*']
-                         end
+if node['yum-centos']['keep_scl_repositories']
+  raise "The node['yum-centos']['keep_scl_repositories'] attribute has been deprecated. SCL repos are now fully \n" \
+        'managed by this cookbook. Please look at the README for more information on how to migrate.'
+end
 
-repositories_to_delete.each do |f|
+::Dir['/etc/yum.repos.d/CentOS-*'].each do |f|
   file f do
     action :delete
   end

--- a/recipes/vault.rb
+++ b/recipes/vault.rb
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-release = node['platform_version']
+release = node['yum-centos']['vault_release']
 
 node['yum-centos']['repos'].each do |id|
   next unless node['yum'][id]['managed']
@@ -30,13 +30,22 @@ node['yum-centos']['repos'].each do |id|
         })
     when 'appstream'
       'AppStream'
-    else
+    when 'powertools'
+      'PowerTools'
+    when 'updates', 'extras', 'centosplus', 'fasttrack'
       id
+    else
+      next
     end
 
   node.default['yum'][id]['description'] = "CentOS-#{release} - #{id.capitalize}"
   node.default['yum'][id]['mirrorlist'] = nil
-  node.default['yum'][id]['baseurl'] = "http://vault.centos.org/#{release}/#{dir}/$basearch/"
+  case node['platform_version'].to_i
+  when 6, 7
+    node.default['yum'][id]['baseurl'] = "http://vault.centos.org/#{release}/#{dir}/$basearch/"
+  when 8
+    node.default['yum'][id]['baseurl'] = "http://vault.centos.org/#{release}/#{dir}/$basearch/os/"
+  end
 end
 
 include_recipe 'yum-centos::default'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -13,28 +13,28 @@ describe 'yum-centos::default' do
       when 6, 7
         it do
           expect(chef_run).to create_yum_repository('base')
-            .with(mirrorlist: "http://mirrorlist.centos.org/?release=#{v}&arch=$basearch&repo=os")
+            .with(mirrorlist: 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os')
         end
         it do
           expect(chef_run).to create_yum_repository('updates')
-            .with(mirrorlist: "http://mirrorlist.centos.org/?release=#{v}&arch=$basearch&repo=updates")
+            .with(mirrorlist: 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates')
         end
         it do
           expect(chef_run).to create_yum_repository('extras')
-            .with(mirrorlist: "http://mirrorlist.centos.org/?release=#{v}&arch=$basearch&repo=extras&infra=$infra")
+            .with(mirrorlist: 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras')
         end
       when 8
         it do
           expect(chef_run).to create_yum_repository('base')
-            .with(mirrorlist: "http://mirrorlist.centos.org/?release=#{v}&arch=$basearch&repo=BaseOS&infra=$infra")
+            .with(mirrorlist: 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=BaseOS')
         end
         it do
           expect(chef_run).to create_yum_repository('appstream')
-            .with(mirrorlist: "http://mirrorlist.centos.org/?release=#{v}&arch=$basearch&repo=AppStream&infra=$infra")
+            .with(mirrorlist: 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=AppStream')
         end
         it do
           expect(chef_run).to create_yum_repository('extras')
-            .with(mirrorlist: "http://mirrorlist.centos.org/?release=#{v}&arch=$basearch&repo=extras&infra=$infra")
+            .with(mirrorlist: 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras')
         end
       end
     end

--- a/test/integration/all/inspec/all_spec.rb
+++ b/test/integration/all/inspec/all_spec.rb
@@ -319,14 +319,6 @@ when 7
     end
   end
 
-  describe yum.repo 'centos-openstack-trunk-tested' do
-    it { should exist }
-    it { should be_enabled }
-    its('baseurl') do
-      should cmp 'https://trunk.rdoproject.org/centos7-train/current-passed-ci/'
-    end
-  end
-
   describe yum.repo 'centos-opstools' do
     it { should exist }
     it { should be_enabled }

--- a/test/integration/all/inspec/all_spec.rb
+++ b/test/integration/all/inspec/all_spec.rb
@@ -2,37 +2,576 @@
 # https://github.com/inspec/inspec/pull/4568
 
 %w(
+  ANSIBLE
   AppStream
+  Azure
   Base
   centosplus
+  Ceph-Nautilus
+  Ceph-Octopus
   CR
   Debuginfo
+  DotNet
   Extras
   fasttrack
+  fdio
+  Gluster-7
+  HA
   Media
+  Messaging-qpid-proton
+  Messaging-rabbitmq
+  NFS-Ganesha-28
+  NFS-Ganesha-3
+  NFS-Ganesha-30
+  nfv-common
+  OpenShift-Origin
+  OpenShift-Origin311
+  OpenStack-train
+  OpenStack-ussuri
+  OpsTools
+  oVirt-4.3
   PowerTools
+  QEMU-EV
+  SCLo-scl
+  SCLo-scl-rh
+  SIG-ansible-29
   Sources
+  Storage-common
   Vault
+  Xen
+  Xen-412
+  Xen-dependencies
 ).each do |name|
   describe file "/etc/yum.repos.d/CentOS-#{name}.repo" do
     it { should_not exist }
   end
 end
 
-repos =
-  case os.release.to_i
-  when 6
-    %w(base updates extras centosplus fasttrack debuginfo contrib)
-  when 7
-    %w(base updates extras centosplus fasttrack debuginfo cr)
-  when 8
-    %w(base appstream powertools extras centosplus fasttrack)
+os_release = os.release.to_i
+
+describe yum.repo 'base' do
+  it { should exist }
+  it { should be_enabled }
+  if os_release == 8
+    its('mirrors') { should cmp "http://mirrorlist.centos.org/?release=#{os_release}&arch=x86_64&repo=BaseOS" }
+  else
+    its('mirrors') { should cmp "http://mirrorlist.centos.org/?release=#{os_release}&arch=x86_64&repo=os" }
+  end
+end
+
+describe yum.repo 'extras' do
+  it { should exist }
+  it { should be_enabled }
+  its('mirrors') { should cmp "http://mirrorlist.centos.org/?release=#{os_release}&arch=x86_64&repo=extras" }
+end
+
+describe yum.repo 'cr' do
+  it { should exist }
+  it { should be_enabled }
+  its('mirrors') { should cmp "http://mirrorlist.centos.org/?release=#{os_release}&arch=x86_64&repo=cr" }
+end
+
+describe yum.repo 'debuginfo' do
+  it { should exist }
+  it { should be_enabled }
+  its('baseurl') { should cmp "http://debuginfo.centos.org/#{os_release}/x86_64/" }
+end
+
+describe yum.repo 'centos-gluster' do
+  it { should exist }
+  it { should be_enabled }
+  its('mirrors') { should cmp "http://mirrorlist.centos.org/?release=#{os_release}&arch=x86_64&repo=storage-gluster-7" }
+end
+
+describe yum.repo 'centos-gluster-testing' do
+  it { should exist }
+  it { should be_enabled }
+  its('baseurl') { should cmp "https://buildlogs.centos.org/centos/#{os_release}/storage/x86_64/gluster-7/" }
+end
+
+case os_release
+when 6
+  describe yum.repo 'updates' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') { should cmp 'http://mirrorlist.centos.org/?release=6&arch=x86_64&repo=updates' }
   end
 
-repos.each do |repo|
-  describe file("/etc/yum.repos.d/#{repo}.repo") do
+  describe yum.repo 'centos-azure' do
     it { should exist }
-    its('owner') { should eq 'root' }
-    its('group') { should eq 'root' }
+    it { should be_enabled }
+    its('mirrors') { should cmp 'http://mirrorlist.centos.org/?release=6&arch=x86_64&repo=virt-azure' }
+  end
+
+  describe yum.repo 'centos-azure-testing' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') { should cmp 'https://buildlogs.centos.org/centos/6/virt/x86_64/azure/' }
+  end
+
+  describe yum.repo 'centos-sclo' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') { should cmp 'http://mirrorlist.centos.org/?release=6&arch=x86_64&repo=sclo-sclo' }
+  end
+
+  describe yum.repo 'centos-sclo-testing' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') { should cmp 'https://buildlogs.centos.org/centos/6/sclo/x86_64/sclo/' }
+  end
+
+  describe yum.repo 'centos-sclo-debuginfo' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') { should cmp 'http://debuginfo.centos.org/centos/6/sclo/x86_64/' }
+  end
+
+  describe yum.repo 'centos-sclo-rh' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') { should cmp 'http://mirrorlist.centos.org/?release=6&arch=x86_64&repo=sclo-rh' }
+  end
+
+  describe yum.repo 'centos-sclo-rh-testing' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') { should cmp 'https://buildlogs.centos.org/centos/6/sclo/x86_64/rh/' }
+  end
+
+  describe yum.repo 'centos-sclo-rh-debuginfo' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') { should cmp 'http://debuginfo.centos.org/centos/6/sclo/x86_64/' }
+  end
+
+  describe yum.repo 'centos-virt-xen' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') { should cmp 'http://mirrorlist.centos.org/?release=6&arch=x86_64&repo=virt-xen-410' }
+  end
+
+  describe yum.repo 'centos-virt-xen-testing' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') { should cmp 'https://buildlogs.centos.org/centos/6/virt/x86_64/xen-410/' }
+  end
+when 7
+  describe yum.repo 'updates' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') { should cmp 'http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=updates' }
+  end
+
+  describe yum.repo 'centos-kernel' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') { should cmp 'http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=kernel' }
+  end
+
+  describe yum.repo 'centos-ansible' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') do
+      should cmp 'http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=configmanagement-ansible-29'
+    end
+  end
+
+  describe yum.repo 'centos-ansible-testing' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') do
+      should cmp 'http://buildlogs.centos.org/centos/7/configmanagement/x86_64/ansible-29/'
+    end
+  end
+
+  describe yum.repo 'centos-ansible-debuginfo' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') do
+      should cmp 'http://debuginfo.centos.org/centos/7/configmanagement/x86_64/'
+    end
+  end
+
+  describe yum.repo 'centos-azure' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') { should cmp 'http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=virt-azure' }
+  end
+
+  describe yum.repo 'centos-azure-testing' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') { should cmp 'https://buildlogs.centos.org/centos/7/virt/x86_64/azure/' }
+  end
+
+  describe yum.repo 'centos-ceph' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') do
+      should cmp 'http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=storage-ceph-nautilus'
+    end
+  end
+
+  describe yum.repo 'centos-ceph-testing' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') do
+      should cmp 'https://buildlogs.centos.org/centos/7/storage/x86_64/ceph-nautilus/'
+    end
+  end
+
+  describe yum.repo 'centos-dotnet' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') { should cmp 'http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=dotnet' }
+  end
+
+  describe yum.repo 'centos-fdio' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') { should cmp 'http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=nfv-fdio' }
+  end
+
+  describe yum.repo 'centos-fdio-testing' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') { should cmp 'https://buildlogs.centos.org/centos/7/nfv/x86_64/fdio/' }
+  end
+
+  describe yum.repo 'centos-nfs-ganesha' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') do
+      should cmp 'http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=storage-nfsganesha-30'
+    end
+  end
+
+  describe yum.repo 'centos-nfs-ganesha-testing' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') do
+      should cmp 'https://buildlogs.centos.org/centos/7/storage/x86_64/nfsganesha-30/'
+    end
+  end
+
+  describe yum.repo 'centos-nfv-common' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') do
+      should cmp 'http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=nfv-common'
+    end
+  end
+
+  describe yum.repo 'centos-nfv-common-testing' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') do
+      should cmp 'https://buildlogs.centos.org/centos/7/nfv/x86_64/nfv-common/'
+    end
+  end
+
+  describe yum.repo 'centos-openshift-origin' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') do
+      should cmp 'http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=paas-openshift-origin311'
+    end
+  end
+
+  describe yum.repo 'centos-openshift-origin-testing' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') do
+      should cmp 'https://buildlogs.centos.org/centos/7/paas/x86_64/openshift-origin311/'
+    end
+  end
+
+  describe yum.repo 'centos-openshift-origin-debuginfo' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') do
+      should cmp 'http://debuginfo.centos.org/centos/7/paas/x86_64/'
+    end
+  end
+
+  describe yum.repo 'centos-openstack' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') do
+      should cmp 'http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=cloud-openstack-train'
+    end
+  end
+
+  describe yum.repo 'centos-openstack-testing' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') do
+      should cmp 'https://buildlogs.centos.org/centos/7/cloud/x86_64/openstack-train/'
+    end
+  end
+
+  describe yum.repo 'centos-openstack-debuginfo' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') do
+      should cmp 'http://debuginfo.centos.org/centos/7/cloud/x86_64/'
+    end
+  end
+
+  describe yum.repo 'centos-openstack-trunk-tested' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') do
+      should cmp 'https://trunk.rdoproject.org/centos7-train/current-passed-ci/'
+    end
+  end
+
+  describe yum.repo 'centos-opstools' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') { should cmp 'http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=opstools' }
+  end
+
+  describe yum.repo 'centos-opstools-testing' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') { should cmp 'https://buildlogs.centos.org/centos/7/opstools/x86_64/' }
+  end
+
+  describe yum.repo 'centos-ovirt' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') { should cmp 'http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=virt-ovirt-4.3' }
+  end
+
+  describe yum.repo 'centos-ovirt-testing' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') { should cmp 'https://buildlogs.centos.org/centos/7/virt/x86_64/ovirt-4.3/' }
+  end
+
+  describe yum.repo 'centos-ovirt-debuginfo' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') { should cmp 'http://debuginfo.centos.org/centos/7/virt/x86_64/' }
+  end
+
+  describe yum.repo 'centos-qemu-ev' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') { should cmp 'http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=virt-kvm-common' }
+  end
+
+  describe yum.repo 'centos-qemu-ev-testing' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') { should cmp 'https://buildlogs.centos.org/centos/7/virt/x86_64/kvm-common/' }
+  end
+
+  describe yum.repo 'centos-sclo' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') { should cmp 'http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=sclo-sclo' }
+  end
+
+  describe yum.repo 'centos-sclo-testing' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') { should cmp 'https://buildlogs.centos.org/centos/7/sclo/x86_64/sclo/' }
+  end
+
+  describe yum.repo 'centos-sclo-debuginfo' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') { should cmp 'http://debuginfo.centos.org/centos/7/sclo/x86_64/' }
+  end
+
+  describe yum.repo 'centos-sclo-rh' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') { should cmp 'http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=sclo-rh' }
+  end
+
+  describe yum.repo 'centos-sclo-rh-testing' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') { should cmp 'https://buildlogs.centos.org/centos/7/sclo/x86_64/rh/' }
+  end
+
+  describe yum.repo 'centos-sclo-rh-debuginfo' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') { should cmp 'http://debuginfo.centos.org/centos/7/sclo/x86_64/' }
+  end
+
+  describe yum.repo 'centos-virt-xen' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') { should cmp 'http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=virt-xen-412' }
+  end
+
+  describe yum.repo 'centos-virt-xen-testing' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') { should cmp 'https://buildlogs.centos.org/centos/7/virt/x86_64/xen-412/' }
+  end
+when 8
+  describe yum.repo 'centos-ansible' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') do
+      should cmp 'http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=configmanagement-ansible-29'
+    end
+  end
+
+  describe yum.repo 'centos-ansible-testing' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') do
+      should cmp 'http://buildlogs.centos.org/centos/8/configmanagement/x86_64/ansible-29/'
+    end
+  end
+
+  describe yum.repo 'centos-ansible-debuginfo' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') do
+      should cmp 'http://debuginfo.centos.org/centos/8/configmanagement/x86_64/'
+    end
+  end
+
+  describe yum.repo 'appstream' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') do
+      should cmp 'http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=AppStream'
+    end
+  end
+
+  describe yum.repo 'centos-ceph' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') do
+      should cmp 'http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=storage-ceph-octopus'
+    end
+  end
+
+  describe yum.repo 'centos-ceph-testing' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') do
+      should cmp 'https://buildlogs.centos.org/centos/8/storage/x86_64/ceph-octopus/'
+    end
+  end
+
+  describe yum.repo 'highavailability' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') do
+      should cmp 'http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=HighAvailability'
+    end
+  end
+
+  describe yum.repo 'centos-nfs-ganesha' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') do
+      should cmp 'http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=storage-nfsganesha-3'
+    end
+  end
+
+  describe yum.repo 'centos-nfs-ganesha-testing' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') do
+      should cmp 'https://buildlogs.centos.org/centos/8/storage/x86_64/nfsganesha-3/'
+    end
+  end
+
+  describe yum.repo 'centos-openstack' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') do
+      should cmp 'http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=cloud-openstack-ussuri'
+    end
+  end
+
+  describe yum.repo 'centos-openstack-testing' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') do
+      should cmp 'https://buildlogs.centos.org/centos/8/cloud/x86_64/openstack-ussuri/'
+    end
+  end
+
+  describe yum.repo 'centos-openstack-debuginfo' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') do
+      should cmp 'http://debuginfo.centos.org/centos/8/cloud/x86_64/'
+    end
+  end
+
+  describe yum.repo 'centos-opstools' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') do
+      should cmp 'http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=opstools-collectd-5'
+    end
+  end
+
+  describe yum.repo 'centos-opstools-testing' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') { should cmp 'https://buildlogs.centos.org/centos/8/opstools/x86_64/collectd-5' }
+  end
+
+  describe yum.repo 'centos-qpid-proton' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') do
+      should cmp 'http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=messaging-qpid-proton'
+    end
+  end
+
+  describe yum.repo 'centos-qpid-proton-testing' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') do
+      should cmp 'https://buildlogs.centos.org/centos/8/messaging/x86_64/qpid-proton'
+    end
+  end
+
+  describe yum.repo 'centos-qpid-proton-debuginfo' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') do
+      should cmp 'http://debuginfo.centos.org/centos/8/messaging/x86_64/'
+    end
+  end
+
+  describe yum.repo 'centos-rabbitmq' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') do
+      should cmp 'http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=messaging-rabbitmq-38'
+    end
+  end
+
+  describe yum.repo 'centos-rabbitmq-testing' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') do
+      should cmp 'https://buildlogs.centos.org/centos/8/messaging/x86_64/rabbitmq-38/'
+    end
+  end
+
+  describe yum.repo 'centos-rabbitmq-debuginfo' do
+    it { should exist }
+    it { should be_enabled }
+    its('baseurl') do
+      should cmp 'http://debuginfo.centos.org/centos/8/messaging/x86_64/'
+    end
   end
 end

--- a/test/integration/vault/inspec/vault_spec.rb
+++ b/test/integration/vault/inspec/vault_spec.rb
@@ -19,21 +19,36 @@
 end
 
 os_release = os.release.to_i
+vault_release =
+  case os.release.to_i
+  when 8
+    '8.0.1905'
+  when 7
+    '7.7.1908'
+  when 6
+    '6.9'
+  end
 
 describe yum.repo 'base' do
   it { should exist }
   it { should be_enabled }
+  its('mirrors') { should cmp nil }
   if os_release == 8
-    its('mirrors') { should cmp "http://mirrorlist.centos.org/?release=#{os_release}&arch=x86_64&repo=BaseOS" }
+    its('baseurl') { should cmp "http://vault.centos.org/#{vault_release}/BaseOS/x86_64/os/" }
   else
-    its('mirrors') { should cmp "http://mirrorlist.centos.org/?release=#{os_release}&arch=x86_64&repo=os" }
+    its('baseurl') { should cmp "http://vault.centos.org/#{vault_release}/os/x86_64/" }
   end
 end
 
 describe yum.repo 'extras' do
   it { should exist }
   it { should be_enabled }
-  its('mirrors') { should cmp "http://mirrorlist.centos.org/?release=#{os_release}&arch=x86_64&repo=extras" }
+  its('mirrors') { should cmp nil }
+  if os_release == 8
+    its('baseurl') { should cmp "http://vault.centos.org/#{vault_release}/extras/x86_64/os/" }
+  else
+    its('baseurl') { should cmp "http://vault.centos.org/#{vault_release}/extras/x86_64/" }
+  end
 end
 
 case os_release
@@ -41,13 +56,15 @@ when 6, 7
   describe yum.repo 'updates' do
     it { should exist }
     it { should be_enabled }
-    its('mirrors') { should cmp "http://mirrorlist.centos.org/?release=#{os_release}&arch=x86_64&repo=updates" }
+    its('mirrors') { should cmp nil }
+    its('baseurl') { should cmp "http://vault.centos.org/#{vault_release}/updates/x86_64/" }
   end
 when 8
   describe yum.repo 'appstream' do
     it { should exist }
     it { should be_enabled }
-    its('mirrors') { should cmp "http://mirrorlist.centos.org/?release=#{os_release}&arch=x86_64&repo=AppStream" }
+    its('mirrors') { should cmp nil }
+    its('baseurl') { should cmp "http://vault.centos.org/#{vault_release}/AppStream/x86_64/os/" }
   end
 end
 


### PR DESCRIPTION
This adds optional SIG (Special Interest Groups) repositories that provide
additional functionality to CentOS. All of these repositories are based on
various centos-release* packages that are a part of the CentOS distribution.

These are all disabled by default.

In addition:
- Changed to using $releasever instead of using ``node['platform_version'].to_i``
- Remove appended ``&infra=$infra`` to mirrorlist URLs as they are not required and make testing easier
- Breaking Change: Remove ``node['yum-centos']['keep_scl_repositories']`` attribute since we manage SCL repos directly
  now
- Update InSpec tests to use yum.repo where it makes sense
- Re-enable debuginfo and cr repos for CentOS 8 now that they are available
- Fix vault recipe and add ``node['yum-centos']['vault_release']`` attribute for setting which version to use. By
  default use previous release.
- Added suite and InSpec tests for vault recipe

Signed-off-by: Lance Albertson <lance@osuosl.org>

<!--- Provide a short summary of your changes in the Title above -->

### Description
<!--- Describe what this change achieves -->

### Issues Resolved
<!--- List any existing issues this PR resolves -->

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>