### PR TITLE
Ensure requiring on cookbook for non-RHEL systems does not return an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file is used to list changes made in each version of the yum-centos cookbook.
 
+## Unreleased
+
+### Added
+- ChefSpec test for non-RHEL systems to ensure compile-time issues are caught
+- Add return in both recipes if the platform family is not RHEL
+
+### Fixed
+- Ensure requiring on cookbook for non-RHEL systems does not return an error (resolves #39)
+
 ## 4.0.0 (2020-07-17)
 
 ### Added

--- a/attributes/centos-ceph.rb
+++ b/attributes/centos-ceph.rb
@@ -1,6 +1,6 @@
 # centos-release-ceph-nautilus : CentOS 7
 # centos-release-ceph-octopus  : CentOS 8
-ver = node['yum-centos']['ceph_version']
+ver = node['yum-centos']['ceph_version'].to_s
 
 default['yum']['centos-ceph']['repositoryid'] = 'centos-ceph'
 default['yum']['centos-ceph']['description'] = "CentOS-$releasever - Ceph #{ver.capitalize}"

--- a/attributes/centos-openstack.rb
+++ b/attributes/centos-openstack.rb
@@ -1,6 +1,6 @@
 # centos-release-openstack-train  : CentOS 7
 # centos-release-openstack-ussuri : CentOS 8
-ver = node['yum-centos']['openstack_version']
+ver = node['yum-centos']['openstack_version'].to_s
 
 default['yum']['centos-openstack']['repositoryid'] = 'centos-openstack'
 default['yum']['centos-openstack']['description'] =

--- a/attributes/centos-opstools.rb
+++ b/attributes/centos-opstools.rb
@@ -1,6 +1,6 @@
 # centos-release-opstools : CentOS 7
 # centos-release-opstools : CentOS 8
-ver = node['yum-centos']['opstools_version']
+ver = node['yum-centos']['opstools_version'].to_s
 
 default['yum']['centos-opstools']['repositoryid'] = 'centos-opstools'
 default['yum']['centos-opstools']['description'] = 'CentOS-$releasever - OpsTools'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -15,6 +15,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+return unless platform_family?('rhel')
 
 if node['yum-centos']['keep_scl_repositories']
   raise "The node['yum-centos']['keep_scl_repositories'] attribute has been deprecated. SCL repos are now fully \n" \

--- a/recipes/vault.rb
+++ b/recipes/vault.rb
@@ -15,6 +15,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+return unless platform_family?('rhel')
 
 include_recipe 'yum-centos::default'
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -39,4 +39,11 @@ describe 'yum-centos::default' do
       end
     end
   end
+  # Make sure we don't break non-RHEL systems which simply include this cookbook
+  context 'ubuntu' do
+    platform 'ubuntu'
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
 end

--- a/spec/unit/recipes/vault_spec.rb
+++ b/spec/unit/recipes/vault_spec.rb
@@ -50,4 +50,11 @@ describe 'yum-centos::vault' do
       end
     end
   end
+  # Make sure we don't break non-RHEL systems which simply include this cookbook
+  context 'ubuntu' do
+    platform 'ubuntu'
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
This resolves #39 which only happens on non-RHEL systems. This is due to the
fact that we're modifying strings in attributes which gets loaded whenver this
cookbook is a dependancy on non-RHEL systems.

This converts whatever value is presented to a string so that the string methods
we use will still work and not cause an error during compile time. In addition,
I added a simple ChefSpec on Ubuntu to try and catch these issues better in the
future.

Signed-off-by: Lance Albertson <lance@osuosl.org>

<!--- Provide a short summary of your changes in the Title above -->

### Description
<!--- Describe what this change achieves -->

### Issues Resolved
<!--- List any existing issues this PR resolves -->

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>