### PR TITLE
Fix Chef 12 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@
           os:
             - 'centos-6'
             - 'centos-7'
+            - 'centos-7-chef-12'
             - 'centos-8'
           suite:
             - 'default'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This file is used to list changes made in each version of the yum-centos cookbook.
 
+## Unreleased
+
+### Fixed
+- Fix Chef 12 compatibility (resolves #42)
+
+### Added
+- Kitchen suite for testing against Chef 12
+
 ## 4.0.1 (2020-07-20)
 
 ### Added

--- a/attributes/centos-opstools.rb
+++ b/attributes/centos-opstools.rb
@@ -18,4 +18,4 @@ default['yum']['centos-opstools-testing']['make_cache'] = true
 default['yum']['centos-opstools-testing']['managed'] = false
 default['yum']['centos-opstools-testing']['gpgcheck'] = false
 default['yum']['centos-opstools-testing']['baseurl'] =
-  "https://buildlogs.centos.org/centos/$releasever/opstools/$basearch/#{ver.delete_prefix('-')}"
+  "https://buildlogs.centos.org/centos/$releasever/opstools/$basearch/#{ver.gsub(/^-/, '')}"

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -25,6 +25,13 @@ platforms:
     image: dokken/centos-7
     pid_one_command: /usr/lib/systemd/systemd
 
+# Ensure compatibility with Chef 12.15
+- name: centos-7-chef-12
+  driver:
+    image: dokken/centos-7
+    pid_one_command: /usr/lib/systemd/systemd
+    chef_version: '12.15.19'
+
 - name: centos-8
   driver:
     image: dokken/centos-8


### PR DESCRIPTION
This resolves #42 by switching to using gsub since delete_prefix isn't supported
in the version of Ruby included in Chef 12.

This also adds a kitchen suite to test against Chef 12 to ensure we catch issues
like this in the future and also adds it to the CI pipeline.

Signed-off-by: Lance Albertson <lance@osuosl.org>

<!--- Provide a short summary of your changes in the Title above -->

### Description
<!--- Describe what this change achieves -->

### Issues Resolved
<!--- List any existing issues this PR resolves -->

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>