### PR TITLE
chore: migrate dependency resolution to Policyfile

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,15 @@
-# Limitations
+# AGENTS.md
+
+## Cookbook Purpose
+
+Installs and configures the CentOS Stream Yum repositories
+
+## Agent Findings
+
+* This cookbook is in an incremental modernization pass. Preserve existing public recipes and attributes unless a later full migration is explicitly selected.
+* Dependency management should use `Policyfile.rb`; do not reintroduce Berkshelf.
+
+## Known Limitations
 
 ## Official support target
 

--- a/Berksfile
+++ b/Berksfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+name 'yum-centos'
+
+run_list 'test::default'
+
+cookbook 'yum-centos', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, 'test::' + recipe_name
+end

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This cookbook now officially supports CentOS Stream 9 and CentOS Stream 10 only.
 * `rt`
 * `resilientstorage`
 
-Use `yum_centos_repository` to manage one repo and `yum_centos_repositories` to manage the default or full set. For lifecycle and architecture limits, see [LIMITATIONS.md](LIMITATIONS.md).
+Use `yum_centos_repository` to manage one repo and `yum_centos_repositories` to manage the default or full set. For lifecycle and architecture limits, see [AGENTS.md](AGENTS.md).
 For migration help from the old attribute-driven cookbook, see [MIGRATION.md](MIGRATION.md).
 
 Legacy names that map cleanly to current Stream repo IDs are also accepted:

--- a/TESTING.md
+++ b/TESTING.md
@@ -3,7 +3,7 @@
 Install Cinc Workstation or Chef Workstation, then install the local integration cookbook:
 
 ```shell
-berks install --only integration
+chef install Policyfile.rb
 ```
 
 Run lint and the unit test suite:

--- a/chefignore
+++ b/chefignore
@@ -83,10 +83,7 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
 #############
-Berksfile
-Berksfile.lock
 cookbooks/*
 tmp
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -29,6 +29,8 @@ suites:
       inspec_tests:
         - path: test/integration/default
   - name: all
+    provisioner:
+      named_run_list: all
     run_list:
       - recipe[test::all]
     verifier:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
## Summary
- migrate dependency resolution from Berksfile to Policyfile
- update ChefSpec setup to use Policyfile resolution
- update Copilot setup to install Chef Workstation 8.0.4 and run chef install Policyfile.rb
- move cookbook limitations into AGENTS.md where present

## Verification
- chef install Policyfile.rb
- cookstyle
- kitchen list
- /opt/chef-workstation/embedded/bin/rspec --format progress